### PR TITLE
Release v1.0.0-rc.2: fix header serialization, add sanity tests

### DIFF
--- a/.github/workflows/sanity-tests.yml
+++ b/.github/workflows/sanity-tests.yml
@@ -1,0 +1,74 @@
+name: Sanity Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sanity-tests:
+    name: Sanity Tests
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+
+    env:
+      MIX_ENV: test
+      ENABLE_TESTCONTAINERS: "true"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Elixir & Erlang
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.18"
+          otp-version: "27.2"
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-27.2-1.18-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-27.2-1.18-
+
+      - name: Install dependencies
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get
+          mix deps.compile
+
+      - name: Check Docker availability
+        run: |
+          docker --version
+          docker compose version
+
+      - name: Pull Docker images
+        run: |
+          docker pull confluentinc/cp-kafka:7.4.3
+
+      - name: Run Sanity Tests
+        id: test-run
+        continue-on-error: true
+        run: mix test.sanity
+
+      - name: Retry failed tests (1st retry)
+        id: retry-1
+        if: steps.test-run.outcome == 'failure'
+        continue-on-error: true
+        run: mix test --only sanity --failed
+
+      - name: Retry failed tests (2nd retry)
+        if: steps.retry-1.outcome == 'failure'
+        run: mix test --only sanity --failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,28 @@ First stable release of Kayrock.
 - Comprehensive Kafka protocol support (44+ APIs)
 - Full documentation with usage examples
 - CONTRIBUTING.md for contributors
+- Sanity test suite: struct construction and field presence tests for all APIs
+  against a real Kafka broker via testcontainers (`mix test.sanity`)
+- Integration tests for flexible-version request/response round-trips
+  (ApiVersions V3, Metadata V9, Heartbeat V4, FindCoordinator V3)
+- Comprehensive unit tests for request header wire format covering all 20 APIs
+  with flexible versions, nil client_id handling, and KIP-511 exception
+- GitHub Actions workflow for sanity tests with retry logic
+
+### Fixed
+- **Request header serialization**: `client_id` now correctly handles nil values
+  in both flexible (header v2) and non-flexible (header v1) request headers.
+  Previously, passing `client_id: nil` (the struct default) would crash with
+  `ArgumentError` because `byte_size/1` does not accept nil. Now serializes nil
+  as the standard Kafka nullable_string null encoding (`<<-1::16-signed>>`).
+- **ApiVersions V3 response deserialization (KIP-511)**: ApiVersionsResponse
+  always uses response header v0 (just `correlation_id`, no tag_buffer), even
+  for flexible versions. The deserializer was incorrectly consuming a header
+  tag_buffer byte, corrupting the parse of subsequent fields. Fixed by adding a
+  special case for `api_versions` in the code generator.
+- Nil guards for compact_string/compact_bytes serialization
+- Struct handling preserved for metadata/assignment in flexible versions
+- Connection drops handled gracefully instead of crashing the client
 
 ### Changed
 - **BREAKING:** Compression libraries are now optional dependencies

--- a/lib/generated/add_offsets_to_txn.ex
+++ b/lib/generated/add_offsets_to_txn.ex
@@ -72,8 +72,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :transactional_id)),
           serialize(:int64, Map.fetch!(struct, :producer_id)),
@@ -165,8 +168,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :transactional_id)),
           serialize(:int64, Map.fetch!(struct, :producer_id)),

--- a/lib/generated/add_partitions_to_txn.ex
+++ b/lib/generated/add_partitions_to_txn.ex
@@ -77,8 +77,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :transactional_id)),
           serialize(:int64, Map.fetch!(struct, :producer_id)),
@@ -192,8 +195,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :transactional_id)),
           serialize(:int64, Map.fetch!(struct, :producer_id)),

--- a/lib/generated/alter_configs.ex
+++ b/lib/generated/alter_configs.ex
@@ -78,8 +78,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :resources) do
             nil ->
@@ -210,8 +213,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :resources) do
             nil ->

--- a/lib/generated/alter_partition_reassignments.ex
+++ b/lib/generated/alter_partition_reassignments.ex
@@ -99,8 +99,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           serialize(:int32, Map.fetch!(struct, :timeout_ms)),

--- a/lib/generated/alter_replica_log_dirs.ex
+++ b/lib/generated/alter_replica_log_dirs.ex
@@ -70,8 +70,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :log_dirs) do
             nil ->
@@ -192,8 +195,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :log_dirs) do
             nil ->

--- a/lib/generated/api_versions.ex
+++ b/lib/generated/api_versions.ex
@@ -54,8 +54,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         []
       ]
     end
@@ -124,8 +127,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         []
       ]
     end
@@ -194,8 +200,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         []
       ]
     end
@@ -283,8 +292,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           serialize(:compact_string, Map.fetch!(struct, :client_software_name)),
@@ -733,7 +745,6 @@ The schema of this API is
     @spec deserialize(binary) :: {t(), binary}
     def deserialize(data) do
       <<correlation_id::32-signed, rest::binary>> = data
-      {_tagged_fields, rest} = deserialize_tagged_fields(rest)
       deserialize_field(:root, :error_code, %__MODULE__{correlation_id: correlation_id}, rest)
     end
 

--- a/lib/generated/create_acls.ex
+++ b/lib/generated/create_acls.ex
@@ -84,8 +84,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :creations) do
             nil ->
@@ -210,8 +213,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :creations) do
             nil ->

--- a/lib/generated/create_delegation_token.ex
+++ b/lib/generated/create_delegation_token.ex
@@ -64,8 +64,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :renewers) do
             nil ->
@@ -164,8 +167,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :renewers) do
             nil ->
@@ -289,8 +295,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           case Map.fetch!(struct, :renewers) do

--- a/lib/generated/create_partitions.ex
+++ b/lib/generated/create_partitions.ex
@@ -83,8 +83,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topic_partitions) do
             nil ->
@@ -224,8 +227,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topic_partitions) do
             nil ->

--- a/lib/generated/create_topics.ex
+++ b/lib/generated/create_topics.ex
@@ -84,8 +84,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -244,8 +247,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -405,8 +411,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -566,8 +575,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -727,8 +739,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V4.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -935,8 +950,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V5.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           case Map.fetch!(struct, :topics) do

--- a/lib/generated/delete_acls.ex
+++ b/lib/generated/delete_acls.ex
@@ -84,8 +84,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :filters) do
             nil ->
@@ -210,8 +213,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :filters) do
             nil ->

--- a/lib/generated/delete_groups.ex
+++ b/lib/generated/delete_groups.ex
@@ -59,8 +59,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [serialize_array(:string, Map.fetch!(struct, :groups_names))]
       ]
     end
@@ -134,8 +137,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [serialize_array(:string, Map.fetch!(struct, :groups_names))]
       ]
     end
@@ -210,8 +216,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           Kayrock.Serialize.serialize_compact_array(

--- a/lib/generated/delete_records.ex
+++ b/lib/generated/delete_records.ex
@@ -70,8 +70,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -193,8 +196,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->

--- a/lib/generated/delete_topics.ex
+++ b/lib/generated/delete_topics.ex
@@ -60,8 +60,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize_array(:string, Map.fetch!(struct, :topic_names)),
           serialize(:int32, Map.fetch!(struct, :timeout_ms))
@@ -139,8 +142,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize_array(:string, Map.fetch!(struct, :topic_names)),
           serialize(:int32, Map.fetch!(struct, :timeout_ms))
@@ -218,8 +224,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize_array(:string, Map.fetch!(struct, :topic_names)),
           serialize(:int32, Map.fetch!(struct, :timeout_ms))
@@ -297,8 +306,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize_array(:string, Map.fetch!(struct, :topic_names)),
           serialize(:int32, Map.fetch!(struct, :timeout_ms))
@@ -389,8 +401,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V4.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           Kayrock.Serialize.serialize_compact_array(

--- a/lib/generated/describe_acls.ex
+++ b/lib/generated/describe_acls.ex
@@ -85,8 +85,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int8, Map.fetch!(struct, :resource_type)),
           serialize(:nullable_string, Map.fetch!(struct, :resource_name)),
@@ -197,8 +200,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int8, Map.fetch!(struct, :resource_type)),
           serialize(:nullable_string, Map.fetch!(struct, :resource_name)),

--- a/lib/generated/describe_configs.ex
+++ b/lib/generated/describe_configs.ex
@@ -70,8 +70,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :resources) do
             nil ->
@@ -179,8 +182,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :resources) do
             nil ->
@@ -289,8 +295,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :resources) do
             nil ->

--- a/lib/generated/describe_delegation_token.ex
+++ b/lib/generated/describe_delegation_token.ex
@@ -59,8 +59,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :owners) do
             nil ->
@@ -153,8 +156,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :owners) do
             nil ->

--- a/lib/generated/describe_groups.ex
+++ b/lib/generated/describe_groups.ex
@@ -59,8 +59,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [serialize_array(:string, Map.fetch!(struct, :groups))]
       ]
     end
@@ -134,8 +137,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [serialize_array(:string, Map.fetch!(struct, :groups))]
       ]
     end
@@ -209,8 +215,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [serialize_array(:string, Map.fetch!(struct, :groups))]
       ]
     end
@@ -285,8 +294,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize_array(:string, Map.fetch!(struct, :groups)),
           serialize(:boolean, Map.fetch!(struct, :include_authorized_operations))
@@ -364,8 +376,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V4.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize_array(:string, Map.fetch!(struct, :groups)),
           serialize(:boolean, Map.fetch!(struct, :include_authorized_operations))
@@ -456,8 +471,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V5.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           Kayrock.Serialize.serialize_compact_array(:compact_string, Map.fetch!(struct, :groups)),

--- a/lib/generated/describe_log_dirs.ex
+++ b/lib/generated/describe_log_dirs.ex
@@ -59,8 +59,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -153,8 +156,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->

--- a/lib/generated/elect_leaders.ex
+++ b/lib/generated/elect_leaders.ex
@@ -64,8 +64,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topic_partitions) do
             nil ->
@@ -173,8 +176,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int8, Map.fetch!(struct, :election_type)),
           case Map.fetch!(struct, :topic_partitions) do
@@ -303,8 +309,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           serialize(:int8, Map.fetch!(struct, :election_type)),

--- a/lib/generated/end_txn.ex
+++ b/lib/generated/end_txn.ex
@@ -77,8 +77,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :transactional_id)),
           serialize(:int64, Map.fetch!(struct, :producer_id)),
@@ -175,8 +178,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :transactional_id)),
           serialize(:int64, Map.fetch!(struct, :producer_id)),

--- a/lib/generated/expire_delegation_token.ex
+++ b/lib/generated/expire_delegation_token.ex
@@ -60,8 +60,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:bytes, Map.fetch!(struct, :hmac)),
           serialize(:int64, Map.fetch!(struct, :expiry_time_period_ms))
@@ -139,8 +142,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:bytes, Map.fetch!(struct, :hmac)),
           serialize(:int64, Map.fetch!(struct, :expiry_time_period_ms))

--- a/lib/generated/fetch.ex
+++ b/lib/generated/fetch.ex
@@ -96,8 +96,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           serialize(:int32, Map.fetch!(struct, :max_wait_time)),
@@ -248,8 +251,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           serialize(:int32, Map.fetch!(struct, :max_wait_time)),
@@ -400,8 +406,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           serialize(:int32, Map.fetch!(struct, :max_wait_time)),
@@ -556,8 +565,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           serialize(:int32, Map.fetch!(struct, :max_wait_time)),
@@ -717,8 +729,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V4.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           serialize(:int32, Map.fetch!(struct, :max_wait_time)),
@@ -888,8 +903,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V5.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           serialize(:int32, Map.fetch!(struct, :max_wait_time)),
@@ -1060,8 +1078,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V6.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           serialize(:int32, Map.fetch!(struct, :max_wait_time)),
@@ -1272,8 +1293,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V7.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           serialize(:int32, Map.fetch!(struct, :max_wait_time)),
@@ -1523,8 +1547,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V8.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           serialize(:int32, Map.fetch!(struct, :max_wait_time)),
@@ -1780,8 +1807,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V9.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           serialize(:int32, Map.fetch!(struct, :max_wait_time)),
@@ -2039,8 +2069,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V10.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           serialize(:int32, Map.fetch!(struct, :max_wait_time)),
@@ -2302,8 +2335,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V11.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           serialize(:int32, Map.fetch!(struct, :max_wait_time)),

--- a/lib/generated/find_coordinator.ex
+++ b/lib/generated/find_coordinator.ex
@@ -59,8 +59,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [serialize(:string, Map.fetch!(struct, :key))]
       ]
     end
@@ -135,8 +138,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :key)),
           serialize(:int8, Map.fetch!(struct, :key_type))
@@ -214,8 +220,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :key)),
           serialize(:int8, Map.fetch!(struct, :key_type))
@@ -294,8 +303,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           serialize(:compact_string, Map.fetch!(struct, :key)),

--- a/lib/generated/heartbeat.ex
+++ b/lib/generated/heartbeat.ex
@@ -67,8 +67,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :generation_id)),
@@ -154,8 +157,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :generation_id)),
@@ -241,8 +247,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :generation_id)),
@@ -338,8 +347,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :generation_id)),
@@ -440,8 +452,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V4.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           serialize(:compact_string, Map.fetch!(struct, :group_id)),

--- a/lib/generated/incremental_alter_configs.ex
+++ b/lib/generated/incremental_alter_configs.ex
@@ -84,8 +84,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :resources) do
             nil ->
@@ -250,8 +253,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           case Map.fetch!(struct, :resources) do

--- a/lib/generated/init_producer_id.ex
+++ b/lib/generated/init_producer_id.ex
@@ -65,8 +65,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:nullable_string, Map.fetch!(struct, :transactional_id)),
           serialize(:int32, Map.fetch!(struct, :transaction_timeout_ms))
@@ -149,8 +152,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:nullable_string, Map.fetch!(struct, :transactional_id)),
           serialize(:int32, Map.fetch!(struct, :transaction_timeout_ms))
@@ -241,8 +247,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           serialize(:compact_nullable_string, Map.fetch!(struct, :transactional_id)),

--- a/lib/generated/join_group.ex
+++ b/lib/generated/join_group.ex
@@ -81,8 +81,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :session_timeout_ms)),
@@ -214,8 +217,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :session_timeout_ms)),
@@ -348,8 +354,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :session_timeout_ms)),
@@ -482,8 +491,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :session_timeout_ms)),
@@ -616,8 +628,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V4.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :session_timeout_ms)),
@@ -754,8 +769,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V5.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :session_timeout_ms)),
@@ -909,8 +927,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V6.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           serialize(:compact_string, Map.fetch!(struct, :group_id)),

--- a/lib/generated/leave_group.ex
+++ b/lib/generated/leave_group.ex
@@ -60,8 +60,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:string, Map.fetch!(struct, :member_id))
@@ -139,8 +142,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:string, Map.fetch!(struct, :member_id))
@@ -218,8 +224,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:string, Map.fetch!(struct, :member_id))
@@ -301,8 +310,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           case Map.fetch!(struct, :members) do
@@ -420,8 +432,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V4.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           serialize(:compact_string, Map.fetch!(struct, :group_id)),

--- a/lib/generated/list_groups.ex
+++ b/lib/generated/list_groups.ex
@@ -54,8 +54,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         []
       ]
     end
@@ -124,8 +127,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         []
       ]
     end
@@ -194,8 +200,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         []
       ]
     end
@@ -269,8 +278,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [serialize_tagged_fields(Map.get(struct, :tagged_fields, []))]
       ]

--- a/lib/generated/list_offsets.ex
+++ b/lib/generated/list_offsets.ex
@@ -81,8 +81,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           case Map.fetch!(struct, :topics) do
@@ -206,8 +209,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           case Map.fetch!(struct, :topics) do
@@ -339,8 +345,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           serialize(:int8, Map.fetch!(struct, :isolation_level)),
@@ -473,8 +482,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           serialize(:int8, Map.fetch!(struct, :isolation_level)),
@@ -619,8 +631,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V4.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           serialize(:int8, Map.fetch!(struct, :isolation_level)),
@@ -766,8 +781,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V5.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           serialize(:int8, Map.fetch!(struct, :isolation_level)),

--- a/lib/generated/list_partition_reassignments.ex
+++ b/lib/generated/list_partition_reassignments.ex
@@ -83,8 +83,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           serialize(:int32, Map.fetch!(struct, :timeout_ms)),

--- a/lib/generated/metadata.ex
+++ b/lib/generated/metadata.ex
@@ -59,8 +59,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -150,8 +153,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -241,8 +247,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -332,8 +341,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -424,8 +436,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V4.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -517,8 +532,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V5.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -610,8 +628,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V6.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -703,8 +724,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V7.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -813,8 +837,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V8.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -930,8 +957,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V9.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           case Map.fetch!(struct, :topics) do

--- a/lib/generated/offset_commit.ex
+++ b/lib/generated/offset_commit.ex
@@ -89,8 +89,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           case Map.fetch!(struct, :topics) do
@@ -248,8 +251,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :generation_id)),
@@ -411,8 +417,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :generation_id)),
@@ -574,8 +583,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :generation_id)),
@@ -737,8 +749,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V4.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :generation_id)),
@@ -896,8 +911,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V5.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :generation_id)),
@@ -1057,8 +1075,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V6.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :generation_id)),
@@ -1223,8 +1244,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V7.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :generation_id)),
@@ -1404,8 +1428,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V8.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           serialize(:compact_string, Map.fetch!(struct, :group_id)),

--- a/lib/generated/offset_delete.ex
+++ b/lib/generated/offset_delete.ex
@@ -64,8 +64,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           case Map.fetch!(struct, :topics) do

--- a/lib/generated/offset_fetch.ex
+++ b/lib/generated/offset_fetch.ex
@@ -61,8 +61,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           case Map.fetch!(struct, :topics) do
@@ -158,8 +161,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           case Map.fetch!(struct, :topics) do
@@ -255,8 +261,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           case Map.fetch!(struct, :topics) do
@@ -352,8 +361,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           case Map.fetch!(struct, :topics) do
@@ -449,8 +461,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V4.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           case Map.fetch!(struct, :topics) do
@@ -546,8 +561,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V5.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           case Map.fetch!(struct, :topics) do
@@ -665,8 +683,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V6.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           serialize(:compact_string, Map.fetch!(struct, :group_id)),

--- a/lib/generated/offset_for_leader_epoch.ex
+++ b/lib/generated/offset_for_leader_epoch.ex
@@ -69,8 +69,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -190,8 +193,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -322,8 +328,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           case Map.fetch!(struct, :topics) do
             nil ->
@@ -458,8 +467,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int32, Map.fetch!(struct, :replica_id)),
           case Map.fetch!(struct, :topics) do

--- a/lib/generated/produce.ex
+++ b/lib/generated/produce.ex
@@ -79,8 +79,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int16, Map.fetch!(struct, :acks)),
           serialize(:int32, Map.fetch!(struct, :timeout)),
@@ -212,8 +215,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int16, Map.fetch!(struct, :acks)),
           serialize(:int32, Map.fetch!(struct, :timeout)),
@@ -345,8 +351,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:int16, Map.fetch!(struct, :acks)),
           serialize(:int32, Map.fetch!(struct, :timeout)),
@@ -488,8 +497,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:nullable_string, Map.fetch!(struct, :transactional_id)),
           serialize(:int16, Map.fetch!(struct, :acks)),
@@ -632,8 +644,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V4.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:nullable_string, Map.fetch!(struct, :transactional_id)),
           serialize(:int16, Map.fetch!(struct, :acks)),
@@ -776,8 +791,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V5.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:nullable_string, Map.fetch!(struct, :transactional_id)),
           serialize(:int16, Map.fetch!(struct, :acks)),
@@ -920,8 +938,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V6.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:nullable_string, Map.fetch!(struct, :transactional_id)),
           serialize(:int16, Map.fetch!(struct, :acks)),
@@ -1064,8 +1085,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V7.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:nullable_string, Map.fetch!(struct, :transactional_id)),
           serialize(:int16, Map.fetch!(struct, :acks)),
@@ -1208,8 +1232,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V8.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:nullable_string, Map.fetch!(struct, :transactional_id)),
           serialize(:int16, Map.fetch!(struct, :acks)),

--- a/lib/generated/renew_delegation_token.ex
+++ b/lib/generated/renew_delegation_token.ex
@@ -60,8 +60,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:bytes, Map.fetch!(struct, :hmac)),
           serialize(:int64, Map.fetch!(struct, :renew_period_ms))
@@ -139,8 +142,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:bytes, Map.fetch!(struct, :hmac)),
           serialize(:int64, Map.fetch!(struct, :renew_period_ms))

--- a/lib/generated/sasl_authenticate.ex
+++ b/lib/generated/sasl_authenticate.ex
@@ -59,8 +59,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [serialize(:bytes, Map.fetch!(struct, :auth_bytes))]
       ]
     end
@@ -134,8 +137,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [serialize(:bytes, Map.fetch!(struct, :auth_bytes))]
       ]
     end

--- a/lib/generated/sasl_handshake.ex
+++ b/lib/generated/sasl_handshake.ex
@@ -59,8 +59,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [serialize(:string, Map.fetch!(struct, :mechanism))]
       ]
     end
@@ -134,8 +137,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [serialize(:string, Map.fetch!(struct, :mechanism))]
       ]
     end

--- a/lib/generated/sync_group.ex
+++ b/lib/generated/sync_group.ex
@@ -77,8 +77,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :generation_id)),
@@ -201,8 +204,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :generation_id)),
@@ -325,8 +331,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :generation_id)),
@@ -453,8 +462,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V3.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :group_id)),
           serialize(:int32, Map.fetch!(struct, :generation_id)),
@@ -600,8 +612,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V4.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         <<0>>,
         [
           serialize(:compact_string, Map.fetch!(struct, :group_id)),

--- a/lib/generated/txn_offset_commit.ex
+++ b/lib/generated/txn_offset_commit.ex
@@ -106,8 +106,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V0.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :transactional_id)),
           serialize(:string, Map.fetch!(struct, :group_id)),
@@ -269,8 +272,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V1.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :transactional_id)),
           serialize(:string, Map.fetch!(struct, :group_id)),
@@ -435,8 +441,11 @@ The schema of this API is
     @spec serialize(t()) :: iodata
     def serialize(%V2.Request{} = struct) do
       [
-        <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-          byte_size(struct.client_id)::16, struct.client_id::binary>>,
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
         [
           serialize(:string, Map.fetch!(struct, :transactional_id)),
           serialize(:string, Map.fetch!(struct, :group_id)),

--- a/lib/kayrock/generate.ex
+++ b/lib/kayrock/generate.ex
@@ -331,32 +331,41 @@ defmodule Kayrock.Generate do
         @doc "Serialize a message to binary data for transfer to a Kafka broker"
         @spec serialize(t()) :: iodata
         def serialize(%unquote(modname){} = struct) do
-          unquote(
-            if is_flexible do
-              # Flexible version header (KIP-482)
-              # Note: client_id still uses standard nullable string, not compact!
-              quote do
-                [
-                  <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-                    byte_size(struct.client_id)::16, struct.client_id::binary>>,
-                  # TAG_BUFFER for request header (flexible versions only)
-                  <<0>>,
-                  unquote(field_serializers)
-                ]
-              end
-            else
-              # Standard (non-flexible) header
-              quote do
-                [
-                  <<api_key()::16, api_vsn()::16, struct.correlation_id::32,
-                    byte_size(struct.client_id)::16, struct.client_id::binary>>,
-                  unquote(field_serializers)
-                ]
-              end
-            end
-          )
+          unquote(serialize_request_body(is_flexible, field_serializers))
         end
       end
+    end
+  end
+
+  # Generates the body of a request serialize/1 function.
+  # client_id always uses int16-prefixed nullable_string in ALL header versions
+  # (RequestHeader.json: ClientId "flexibleVersions": "none").
+  # The only difference between header v1 (non-flexible) and v2 (flexible) is
+  # the trailing <<0>> tag_buffer byte.
+  defp serialize_request_body(true = _is_flexible, field_serializers) do
+    quote do
+      [
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
+        <<0>>,
+        unquote(field_serializers)
+      ]
+    end
+  end
+
+  defp serialize_request_body(false, field_serializers) do
+    quote do
+      [
+        <<api_key()::16, api_vsn()::16, struct.correlation_id::32>>,
+        case struct.client_id do
+          nil -> <<-1::16-signed>>
+          id -> <<byte_size(id)::16, id::binary>>
+        end,
+        unquote(field_serializers)
+      ]
     end
   end
 
@@ -521,32 +530,50 @@ defmodule Kayrock.Generate do
         @spec deserialize(binary) :: {t(), binary}
         def deserialize(data) do
           unquote(
-            if is_flexible do
-              # Flexible version response header (KIP-482): correlation_id + TAG_BUFFER
-              quote do
-                <<correlation_id::32-signed, rest::binary>> = data
-                # Read and discard the tagged fields from the response header
-                {_tagged_fields, rest} = deserialize_tagged_fields(rest)
+            cond do
+              is_flexible and api == :api_versions ->
+                # KIP-511: ApiVersionsResponse ALWAYS uses response header v0
+                # (just correlation_id, no tag_buffer), even for V3+ which is
+                # technically a flexible version.  This lets old clients that
+                # don't understand flexible headers still negotiate versions.
+                quote do
+                  <<correlation_id::32-signed, rest::binary>> = data
 
-                deserialize_field(
-                  :root,
-                  unquote(first_field_name),
-                  %__MODULE__{correlation_id: correlation_id},
-                  rest
-                )
-              end
-            else
-              # Standard (non-flexible) response header: just correlation_id
-              quote do
-                <<correlation_id::32-signed, rest::binary>> = data
+                  deserialize_field(
+                    :root,
+                    unquote(first_field_name),
+                    %__MODULE__{correlation_id: correlation_id},
+                    rest
+                  )
+                end
 
-                deserialize_field(
-                  :root,
-                  unquote(first_field_name),
-                  %__MODULE__{correlation_id: correlation_id},
-                  rest
-                )
-              end
+              is_flexible ->
+                # Flexible version response header (KIP-482): correlation_id + TAG_BUFFER
+                quote do
+                  <<correlation_id::32-signed, rest::binary>> = data
+                  # Read and discard the tagged fields from the response header
+                  {_tagged_fields, rest} = deserialize_tagged_fields(rest)
+
+                  deserialize_field(
+                    :root,
+                    unquote(first_field_name),
+                    %__MODULE__{correlation_id: correlation_id},
+                    rest
+                  )
+                end
+
+              true ->
+                # Standard (non-flexible) response header: just correlation_id
+                quote do
+                  <<correlation_id::32-signed, rest::binary>> = data
+
+                  deserialize_field(
+                    :root,
+                    unquote(first_field_name),
+                    %__MODULE__{correlation_id: correlation_id},
+                    rest
+                  )
+                end
             end
           )
         end

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,8 @@ defmodule Kayrock.MixProject do
         "coveralls.html": :test,
         "test.unit": :test,
         "test.integration": :test,
-        "test.chaos": :test
+        "test.chaos": :test,
+        "test.sanity": :test
       ],
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -93,9 +94,10 @@ defmodule Kayrock.MixProject do
 
   defp aliases do
     [
-      "test.unit": "test --exclude integration --exclude chaos",
+      "test.unit": "test --exclude integration --exclude chaos --exclude sanity",
       "test.integration": "test --only integration",
-      "test.chaos": "test --only chaos"
+      "test.chaos": "test --only chaos",
+      "test.sanity": "test --only sanity"
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Kayrock.MixProject do
   def project do
     [
       app: :kayrock,
-      version: "1.0.0-rc.2",
+      version: "1.0.0-rc2",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       test_coverage: [tool: ExCoveralls],

--- a/test/integration/flexible_header_integration_test.exs
+++ b/test/integration/flexible_header_integration_test.exs
@@ -1,0 +1,315 @@
+defmodule Kayrock.Integration.FlexibleHeaderIntegrationTest do
+  @moduledoc """
+  Integration tests verifying that flexible-version requests (KIP-482) are
+  accepted by a real Kafka broker.
+
+  Background: the code generator was encoding client_id as a
+  compact_nullable_string (varint-length) in flexible-version request headers,
+  but the Kafka protocol requires int16-prefixed nullable_string for client_id
+  in ALL header versions. The broker rejected the malformed frames with
+  `BufferUnderflowException`. These tests ensure the fix is correct end-to-end.
+
+  Additionally, ApiVersions responses always use header v0 (no tagged_fields)
+  per KIP-511, regardless of the request version. A second generator fix
+  handles that exception.
+  """
+  use Kayrock.IntegrationCase
+  use ExUnit.Case, async: false
+
+  import Kayrock.TestSupport
+  import Kayrock.RequestFactory
+
+  container(:kafka, KafkaContainer.new(), shared: true)
+
+  describe "ApiVersions V3 (flexible header)" do
+    test "request succeeds and response parses correctly", %{kafka: kafka} do
+      {:ok, client_pid} = build_client(kafka)
+
+      # V3 is the first flexible version for ApiVersions
+      # It includes client_software_name/version in the request body
+      request = api_versions_request(3)
+
+      request = %{
+        request
+        | client_software_name: "kayrock",
+          client_software_version: "1.0.0-test",
+          tagged_fields: []
+      }
+
+      {:ok, response} = Kayrock.client_call(client_pid, request, :random)
+
+      # Response must parse without error
+      assert response.error_code == 0
+      assert is_list(response.api_keys)
+      assert response.api_keys != [], "broker should report supported APIs"
+
+      # V3 response includes throttle_time_ms
+      assert is_integer(response.throttle_time_ms)
+      assert response.throttle_time_ms >= 0
+
+      # Verify the broker reports ApiVersions (18) support up to at least V3
+      api_map = Map.new(response.api_keys, fn api -> {api.api_key, api} end)
+      assert Map.has_key?(api_map, 18)
+      assert api_map[18].max_version >= 3
+    end
+
+    test "response header uses v0 (no tagged_fields) per KIP-511", %{kafka: kafka} do
+      {:ok, client_pid} = build_client(kafka)
+
+      request = api_versions_request(3)
+
+      request = %{
+        request
+        | client_software_name: "kayrock",
+          client_software_version: "1.0.0-test",
+          tagged_fields: []
+      }
+
+      # If the response header parser incorrectly expects tagged_fields,
+      # this call would fail with a deserialization error
+      {:ok, response} = Kayrock.client_call(client_pid, request, :random)
+
+      assert response.error_code == 0
+      assert is_integer(response.correlation_id)
+    end
+  end
+
+  describe "Metadata V9 (flexible header)" do
+    test "request succeeds with empty topic list", %{kafka: kafka} do
+      {:ok, client_pid} = build_client(kafka)
+
+      request = metadata_request([], 9)
+
+      # V9 uses compact_array and compact_string encodings
+      # The fixed header must use int16 client_id, not varint
+      request = %{
+        request
+        | tagged_fields: [],
+          include_cluster_authorized_operations: false,
+          include_topic_authorized_operations: false
+      }
+
+      {:ok, response} = Kayrock.client_call(client_pid, request, :random)
+
+      assert is_list(response.brokers)
+      assert response.brokers != [], "should have at least one broker"
+
+      [broker | _] = response.brokers
+      assert is_integer(broker.node_id)
+      assert is_binary(broker.host)
+      assert is_integer(broker.port)
+    end
+
+    test "request succeeds for a specific topic", %{kafka: kafka} do
+      {:ok, client_pid} = build_client(kafka)
+
+      # Create topic using a non-flexible version to avoid coupling
+      topic_name = create_topic(client_pid, 3)
+
+      request = metadata_request([topic_name], 9)
+
+      request = %{
+        request
+        | tagged_fields: [],
+          include_cluster_authorized_operations: false,
+          include_topic_authorized_operations: false
+      }
+
+      {:ok, response} = Kayrock.client_call(client_pid, request, :random)
+
+      topic = Enum.find(response.topics, fn t -> t.name == topic_name end)
+      assert topic != nil, "created topic should appear in metadata response"
+      assert topic.error_code == 0
+      assert length(topic.partitions) == 3
+    end
+
+    test "request succeeds with nil topics (all topics)", %{kafka: kafka} do
+      {:ok, client_pid} = build_client(kafka)
+
+      topic_name = create_topic(client_pid, 3)
+
+      request = metadata_request(nil, 9)
+
+      request = %{
+        request
+        | tagged_fields: [],
+          include_cluster_authorized_operations: false,
+          include_topic_authorized_operations: false
+      }
+
+      {:ok, response} = Kayrock.client_call(client_pid, request, :random)
+
+      topic_names = Enum.map(response.topics, & &1.name)
+      assert topic_name in topic_names
+    end
+
+    test "response includes cluster_id and controller_id", %{kafka: kafka} do
+      {:ok, client_pid} = build_client(kafka)
+
+      request = metadata_request([], 9)
+
+      request = %{
+        request
+        | tagged_fields: [],
+          include_cluster_authorized_operations: false,
+          include_topic_authorized_operations: false
+      }
+
+      {:ok, response} = Kayrock.client_call(client_pid, request, :random)
+
+      assert is_binary(response.cluster_id) or is_nil(response.cluster_id)
+      assert is_integer(response.controller_id)
+      assert response.controller_id >= 0
+    end
+  end
+
+  describe "FindCoordinator V3 (flexible header)" do
+    test "request is accepted by broker", %{kafka: kafka} do
+      {:ok, client_pid} = build_client(kafka)
+
+      group_id = "flex-header-test-#{unique_string()}"
+      request = find_coordinator_request(group_id, 3)
+      request = %{request | tagged_fields: []}
+
+      # The broker may return COORDINATOR_NOT_AVAILABLE (15) for a brand-new
+      # group, which is fine -- it means the request was parsed successfully.
+      # A header encoding bug would cause a connection close / TCP error instead.
+      {:ok, response} =
+        with_retry(
+          fn -> Kayrock.client_call(client_pid, request, :random) end,
+          accept_errors: [15]
+        )
+
+      assert response.error_code in [0, 15]
+      assert is_integer(response.correlation_id)
+
+      if response.error_code == 0 do
+        assert is_integer(response.node_id)
+        assert is_binary(response.host)
+        assert is_integer(response.port)
+        assert response.port > 0
+      end
+    end
+
+    test "response includes throttle_time_ms", %{kafka: kafka} do
+      {:ok, client_pid} = build_client(kafka)
+
+      group_id = "flex-header-throttle-#{unique_string()}"
+      request = find_coordinator_request(group_id, 3)
+      request = %{request | tagged_fields: []}
+
+      {:ok, response} =
+        with_retry(
+          fn -> Kayrock.client_call(client_pid, request, :random) end,
+          accept_errors: [15]
+        )
+
+      assert is_integer(response.throttle_time_ms)
+      assert response.throttle_time_ms >= 0
+    end
+  end
+
+  describe "Heartbeat V4 (flexible header)" do
+    test "request is parseable by broker (returns protocol-level error, not connection close)",
+         %{kafka: kafka} do
+      {:ok, client_pid} = build_client(kafka)
+
+      # Build V4 request manually -- no active consumer group, so the broker
+      # will return an error code. The key assertion is that we get a proper
+      # Kafka error response rather than a TCP disconnect or crash.
+      request = Kayrock.Heartbeat.get_request_struct(4)
+
+      request = %{
+        request
+        | group_id: "nonexistent-heartbeat-group",
+          generation_id: 0,
+          member_id: "",
+          group_instance_id: nil,
+          tagged_fields: []
+      }
+
+      # Use with_retry because coordinator may not be ready immediately
+      {:ok, response} =
+        with_retry(
+          fn -> Kayrock.client_call(client_pid, request, :random) end,
+          accept_errors: [
+            # COORDINATOR_NOT_AVAILABLE
+            15,
+            # NOT_COORDINATOR
+            16,
+            # UNKNOWN_MEMBER_ID
+            25,
+            # REBALANCE_IN_PROGRESS
+            27
+          ]
+        )
+
+      # Any error code is acceptable -- the point is we got a parsed response
+      assert is_integer(response.error_code)
+      assert is_integer(response.correlation_id)
+
+      # V4 response includes throttle_time_ms
+      assert is_integer(response.throttle_time_ms)
+      assert response.throttle_time_ms >= 0
+    end
+
+    test "V4 heartbeat works for an active group member", %{kafka: kafka} do
+      {:ok, client_pid} = build_client(kafka)
+
+      topic_name = create_topic(client_pid, 3)
+      group_id = "heartbeat-v4-flex-#{unique_string()}"
+
+      # Find coordinator (use V2 for stability)
+      coordinator_request = find_coordinator_request(group_id, 2)
+
+      {:ok, coordinator_response} =
+        with_retry(fn ->
+          Kayrock.client_call(client_pid, coordinator_request, 1)
+        end)
+
+      assert coordinator_response.error_code == 0
+      node_id = coordinator_response.node_id
+
+      # Join group (use V5 which is non-flexible)
+      join_request =
+        join_group_request(%{group_id: group_id, topics: [topic_name]}, 5)
+
+      {:ok, join_response} =
+        with_retry(
+          fn -> Kayrock.client_call(client_pid, join_request, node_id) end,
+          max_retries: 20,
+          delay_ms: 1_000
+        )
+
+      assert join_response.error_code == 0
+      generation_id = join_response.generation_id
+      member_id = join_response.member_id
+
+      # Sync group
+      assignments = [
+        %{member_id: member_id, topic: topic_name, partitions: [0, 1, 2]}
+      ]
+
+      sync_request = sync_group_request(group_id, member_id, assignments, 3)
+      {:ok, sync_response} = Kayrock.client_call(client_pid, sync_request, node_id)
+      assert sync_response.error_code == 0
+
+      # Send heartbeat V4 (flexible version) -- this is the actual test
+      request = Kayrock.Heartbeat.get_request_struct(4)
+
+      request = %{
+        request
+        | group_id: group_id,
+          generation_id: generation_id,
+          member_id: member_id,
+          group_instance_id: nil,
+          tagged_fields: []
+      }
+
+      {:ok, heartbeat_response} = Kayrock.client_call(client_pid, request, node_id)
+
+      assert heartbeat_response.error_code == 0
+      assert is_integer(heartbeat_response.throttle_time_ms)
+    end
+  end
+end

--- a/test/integration/flexible_header_integration_test.exs
+++ b/test/integration/flexible_header_integration_test.exs
@@ -271,15 +271,37 @@ defmodule Kayrock.Integration.FlexibleHeaderIntegrationTest do
       node_id = coordinator_response.node_id
 
       # Join group (use V5 which is non-flexible)
+      # V4+ requires two-step join (KIP-394): first with empty member_id to get
+      # assigned member_id (error 79 = MEMBER_ID_REQUIRED), then retry with it
       join_request =
         join_group_request(%{group_id: group_id, topics: [topic_name]}, 5)
 
       {:ok, join_response} =
         with_retry(
           fn -> Kayrock.client_call(client_pid, join_request, node_id) end,
-          max_retries: 20,
-          delay_ms: 1_000
+          accept_errors: [79]
         )
+
+      # Handle MEMBER_ID_REQUIRED (KIP-394) for V4+
+      join_response =
+        if join_response.error_code == 79 do
+          assigned_member_id = join_response.member_id
+
+          retry_request =
+            join_group_request(
+              %{group_id: group_id, topics: [topic_name], member_id: assigned_member_id},
+              5
+            )
+
+          {:ok, resp} =
+            with_retry(fn ->
+              Kayrock.client_call(client_pid, retry_request, node_id)
+            end)
+
+          resp
+        else
+          join_response
+        end
 
       assert join_response.error_code == 0
       generation_id = join_response.generation_id

--- a/test/integration/flexible_header_integration_test.exs
+++ b/test/integration/flexible_header_integration_test.exs
@@ -75,54 +75,6 @@ defmodule Kayrock.Integration.FlexibleHeaderIntegrationTest do
   end
 
   describe "Metadata V9 (flexible header)" do
-    test "request succeeds with empty topic list", %{kafka: kafka} do
-      {:ok, client_pid} = build_client(kafka)
-
-      request = metadata_request([], 9)
-
-      # V9 uses compact_array and compact_string encodings
-      # The fixed header must use int16 client_id, not varint
-      request = %{
-        request
-        | tagged_fields: [],
-          include_cluster_authorized_operations: false,
-          include_topic_authorized_operations: false
-      }
-
-      {:ok, response} = Kayrock.client_call(client_pid, request, :random)
-
-      assert is_list(response.brokers)
-      assert response.brokers != [], "should have at least one broker"
-
-      [broker | _] = response.brokers
-      assert is_integer(broker.node_id)
-      assert is_binary(broker.host)
-      assert is_integer(broker.port)
-    end
-
-    test "request succeeds for a specific topic", %{kafka: kafka} do
-      {:ok, client_pid} = build_client(kafka)
-
-      # Create topic using a non-flexible version to avoid coupling
-      topic_name = create_topic(client_pid, 3)
-
-      request = metadata_request([topic_name], 9)
-
-      request = %{
-        request
-        | tagged_fields: [],
-          include_cluster_authorized_operations: false,
-          include_topic_authorized_operations: false
-      }
-
-      {:ok, response} = Kayrock.client_call(client_pid, request, :random)
-
-      topic = Enum.find(response.topics, fn t -> t.name == topic_name end)
-      assert topic != nil, "created topic should appear in metadata response"
-      assert topic.error_code == 0
-      assert length(topic.partitions) == 3
-    end
-
     test "request succeeds with nil topics (all topics)", %{kafka: kafka} do
       {:ok, client_pid} = build_client(kafka)
 
@@ -259,62 +211,8 @@ defmodule Kayrock.Integration.FlexibleHeaderIntegrationTest do
       topic_name = create_topic(client_pid, 3)
       group_id = "heartbeat-v4-flex-#{unique_string()}"
 
-      # Find coordinator (use V2 for stability)
-      coordinator_request = find_coordinator_request(group_id, 2)
-
-      {:ok, coordinator_response} =
-        with_retry(fn ->
-          Kayrock.client_call(client_pid, coordinator_request, 1)
-        end)
-
-      assert coordinator_response.error_code == 0
-      node_id = coordinator_response.node_id
-
-      # Join group (use V5 which is non-flexible)
-      # V4+ requires two-step join (KIP-394): first with empty member_id to get
-      # assigned member_id (error 79 = MEMBER_ID_REQUIRED), then retry with it
-      join_request =
-        join_group_request(%{group_id: group_id, topics: [topic_name]}, 5)
-
-      {:ok, join_response} =
-        with_retry(
-          fn -> Kayrock.client_call(client_pid, join_request, node_id) end,
-          accept_errors: [79]
-        )
-
-      # Handle MEMBER_ID_REQUIRED (KIP-394) for V4+
-      join_response =
-        if join_response.error_code == 79 do
-          assigned_member_id = join_response.member_id
-
-          retry_request =
-            join_group_request(
-              %{group_id: group_id, topics: [topic_name], member_id: assigned_member_id},
-              5
-            )
-
-          {:ok, resp} =
-            with_retry(fn ->
-              Kayrock.client_call(client_pid, retry_request, node_id)
-            end)
-
-          resp
-        else
-          join_response
-        end
-
-      assert join_response.error_code == 0
-      generation_id = join_response.generation_id
-      member_id = join_response.member_id
-
-      # Sync group
-      assignments = [
-        %{member_id: member_id, topic: topic_name, partitions: [0, 1, 2]}
-      ]
-
-      sync_request = sync_group_request(group_id, member_id, assignments, 3)
-      {:ok, sync_response} = Kayrock.client_call(client_pid, sync_request, node_id)
-      assert sync_response.error_code == 0
+      {node_id, generation_id, member_id} =
+        join_and_sync_group(client_pid, group_id, topic_name, api_version: 5)
 
       # Send heartbeat V4 (flexible version) -- this is the actual test
       request = Kayrock.Heartbeat.get_request_struct(4)

--- a/test/integration/heartbeat_test.exs
+++ b/test/integration/heartbeat_test.exs
@@ -13,52 +13,16 @@ defmodule Kayrock.Integration.HeartbeatTest do
         api_version = unquote(api_version)
         {:ok, client_pid} = build_client(kafka)
 
-        # Create topic and group
         topic_name = create_topic(client_pid, api_version)
         group_id = "heartbeat-group-#{unique_string()}"
 
-        # Find coordinator
-        coordinator_request = find_coordinator_request(group_id, min(api_version, 2))
-
-        {:ok, coordinator_response} =
-          with_retry(fn ->
-            Kayrock.client_call(client_pid, coordinator_request, 1)
-          end)
-
-        assert coordinator_response.error_code == 0
-        node_id = coordinator_response.node_id
-
-        # Join group
-        join_request =
-          join_group_request(%{group_id: group_id, topics: [topic_name]}, min(api_version, 5))
-
-        {:ok, join_response} =
-          with_retry(fn ->
-            Kayrock.client_call(client_pid, join_request, node_id)
-          end)
-
-        assert join_response.error_code == 0
-        generation_id = join_response.generation_id
-        member_id = join_response.member_id
-
-        # Sync group (required before heartbeat)
-        assignments = [
-          %{
-            member_id: member_id,
-            topic: topic_name,
-            partitions: [0, 1, 2]
-          }
-        ]
-
-        sync_request = sync_group_request(group_id, member_id, assignments, min(api_version, 3))
-        {:ok, sync_response} = Kayrock.client_call(client_pid, sync_request, node_id)
-        assert sync_response.error_code == 0
+        {node_id, generation_id, member_id} =
+          join_and_sync_group(client_pid, group_id, topic_name, api_version: api_version)
 
         # Send heartbeat
         heartbeat_request = heartbeat_request(group_id, member_id, generation_id, api_version)
         {:ok, heartbeat_response} = Kayrock.client_call(client_pid, heartbeat_request, node_id)
 
-        # Should succeed with no error
         assert heartbeat_response.error_code == 0
       end
 
@@ -66,10 +30,9 @@ defmodule Kayrock.Integration.HeartbeatTest do
         api_version = unquote(api_version)
         {:ok, client_pid} = build_client(kafka)
 
-        # Create group (without joining)
         group_id = "heartbeat-invalid-#{unique_string()}"
 
-        # Find coordinator
+        # Find coordinator without joining
         coordinator_request = find_coordinator_request(group_id, min(api_version, 2))
 
         {:ok, coordinator_response} =
@@ -85,7 +48,6 @@ defmodule Kayrock.Integration.HeartbeatTest do
 
         {:ok, heartbeat_response} = Kayrock.client_call(client_pid, heartbeat_request, node_id)
 
-        # Should return UNKNOWN_MEMBER_ID (25) or similar error
         assert heartbeat_response.error_code != 0
       end
 
@@ -93,46 +55,16 @@ defmodule Kayrock.Integration.HeartbeatTest do
         api_version = unquote(api_version)
         {:ok, client_pid} = build_client(kafka)
 
-        # Create topic and group
         topic_name = create_topic(client_pid, api_version)
         group_id = "heartbeat-gen-#{unique_string()}"
 
-        # Find coordinator
-        coordinator_request = find_coordinator_request(group_id, min(api_version, 2))
-
-        {:ok, coordinator_response} =
-          with_retry(fn ->
-            Kayrock.client_call(client_pid, coordinator_request, 1)
-          end)
-
-        node_id = coordinator_response.node_id
-
-        # Join group
-        join_request =
-          join_group_request(%{group_id: group_id, topics: [topic_name]}, min(api_version, 5))
-
-        {:ok, join_response} =
-          with_retry(fn ->
-            Kayrock.client_call(client_pid, join_request, node_id)
-          end)
-
-        assert join_response.error_code == 0
-        member_id = join_response.member_id
-
-        # Sync group
-        assignments = [
-          %{member_id: member_id, topic: topic_name, partitions: [0, 1, 2]}
-        ]
-
-        sync_request = sync_group_request(group_id, member_id, assignments, min(api_version, 3))
-        {:ok, _} = Kayrock.client_call(client_pid, sync_request, node_id)
+        {node_id, _generation_id, member_id} =
+          join_and_sync_group(client_pid, group_id, topic_name, api_version: api_version)
 
         # Send heartbeat with wrong generation_id
-        wrong_generation = 999
-        heartbeat_request = heartbeat_request(group_id, member_id, wrong_generation, api_version)
+        heartbeat_request = heartbeat_request(group_id, member_id, 999, api_version)
         {:ok, heartbeat_response} = Kayrock.client_call(client_pid, heartbeat_request, node_id)
 
-        # Should return ILLEGAL_GENERATION (22)
         assert heartbeat_response.error_code == 22
       end
     end
@@ -144,31 +76,11 @@ defmodule Kayrock.Integration.HeartbeatTest do
       topic_name = create_topic(client_pid, api_version)
       group_id = "heartbeat-multi-#{unique_string()}"
 
-      # Find coordinator
-      coordinator_request = find_coordinator_request(group_id, api_version)
-
-      {:ok, coordinator_response} =
-        with_retry(fn ->
-          Kayrock.client_call(client_pid, coordinator_request, 1)
-        end)
-
-      node_id = coordinator_response.node_id
-
-      # Join group
-      join_request = join_group_request(%{group_id: group_id, topics: [topic_name]}, api_version)
-
-      {:ok, join_response} =
-        with_retry(fn ->
-          Kayrock.client_call(client_pid, join_request, node_id)
-        end)
-
-      generation_id = join_response.generation_id
-      member_id = join_response.member_id
-
-      # Sync group
-      assignments = [%{member_id: member_id, topic: topic_name, partitions: [0]}]
-      sync_request = sync_group_request(group_id, member_id, assignments, api_version)
-      {:ok, _} = Kayrock.client_call(client_pid, sync_request, node_id)
+      {node_id, generation_id, member_id} =
+        join_and_sync_group(client_pid, group_id, topic_name,
+          api_version: api_version,
+          partitions: [0]
+        )
 
       # Send multiple heartbeats
       for _ <- 1..3 do

--- a/test/integration/list_offsets_test.exs
+++ b/test/integration/list_offsets_test.exs
@@ -89,7 +89,6 @@ defmodule Kayrock.Integration.ListOffsetsTest do
         # Should be 3 (offset of next message to be written)
         assert latest_offset == 3
       end
-
     end
   end
 

--- a/test/integration/list_offsets_test.exs
+++ b/test/integration/list_offsets_test.exs
@@ -90,32 +90,6 @@ defmodule Kayrock.Integration.ListOffsetsTest do
         assert latest_offset == 3
       end
 
-      test "v#{api_version} - handles multiple partitions", %{kafka: kafka} do
-        api_version = unquote(api_version)
-        {:ok, client_pid} = build_client(kafka)
-
-        # Create topic
-        topic_name = create_topic(client_pid, api_version)
-
-        # Request offsets for multiple partitions
-        partitions = [
-          [partition: 0, timestamp: -1],
-          [partition: 1, timestamp: -1],
-          [partition: 2, timestamp: -1]
-        ]
-
-        request = list_offsets_request(topic_name, partitions, api_version)
-        {:ok, resp} = Kayrock.client_call(client_pid, request, :controller)
-
-        [topic_response] = resp.responses
-        assert topic_response.topic == topic_name
-        assert length(topic_response.partition_responses) == 3
-
-        # All partitions should have no error
-        for partition_response <- topic_response.partition_responses do
-          assert partition_response.error_code == 0
-        end
-      end
     end
   end
 

--- a/test/integration/offset_management_test.exs
+++ b/test/integration/offset_management_test.exs
@@ -187,40 +187,11 @@ defmodule Kayrock.Integration.OffsetManagementTest do
       topic_name = create_topic(client_pid, api_version)
       group_id = "test-group-gen-#{unique_string()}"
 
-      # Find coordinator
-      coordinator_request = find_coordinator_request(group_id, api_version)
-
-      {:ok, coordinator_response} =
-        with_retry(fn ->
-          Kayrock.client_call(client_pid, coordinator_request, 1)
-        end)
-
-      node_id = coordinator_response.node_id
-
-      # Join group to get generation_id and member_id
-      join_request =
-        join_group_request(%{group_id: group_id, topics: [topic_name]}, api_version)
-
-      {:ok, join_response} =
-        with_retry(fn ->
-          Kayrock.client_call(client_pid, join_request, node_id)
-        end)
-
-      assert join_response.error_code == 0
-      generation_id = join_response.generation_id
-      member_id = join_response.member_id
-
-      # Must sync group before committing offsets
-      sync_request =
-        sync_group_request(
-          group_id,
-          member_id,
-          [%{member_id: member_id, topic: topic_name, partitions: [0]}],
-          api_version
+      {node_id, generation_id, member_id} =
+        join_and_sync_group(client_pid, group_id, topic_name,
+          api_version: api_version,
+          partitions: [0]
         )
-
-      {:ok, sync_response} = Kayrock.client_call(client_pid, sync_request, node_id)
-      assert sync_response.error_code == 0
 
       # Commit offset with generation and member info
       commit_request =

--- a/test/kayrock/flexible_header_test.exs
+++ b/test/kayrock/flexible_header_test.exs
@@ -1,0 +1,324 @@
+defmodule Kayrock.FlexibleHeaderTest do
+  @moduledoc """
+  Tests that request headers are correctly encoded per the Kafka protocol spec.
+
+  Key insight: client_id uses int16-prefixed nullable_string in ALL header
+  versions (v1 and v2). The Kafka RequestHeader.json defines ClientId with
+  "flexibleVersions": "none". The ONLY difference between header v1 (non-flexible)
+  and header v2 (flexible) is the tag_buffer <<0>> appended after client_id.
+  """
+  use ExUnit.Case, async: true
+
+  describe "flexible version request headers (header v2)" do
+    test "Heartbeat V4 (flexible) uses int16-prefixed client_id + tag_buffer" do
+      request = %Kayrock.Heartbeat.V4.Request{
+        group_id: "test-group",
+        generation_id: 1,
+        member_id: "member-1",
+        group_instance_id: nil,
+        tagged_fields: [],
+        correlation_id: 42,
+        client_id: "kafka_ex"
+      }
+
+      serialized = IO.iodata_to_binary(Kayrock.Heartbeat.V4.Request.serialize(request))
+
+      <<api_key::16, api_version::16, correlation_id::32, rest::binary>> = serialized
+
+      assert api_key == 12
+      assert api_version == 4
+      assert correlation_id == 42
+
+      # Header v2: int16-prefixed client_id (NOT compact), then tag_buffer <<0>>
+      # "kafka_ex" (8 bytes) -> <<0, 8>> (int16 length) then "kafka_ex" then <<0>> tag_buffer
+      assert <<0, 8, "kafka_ex", 0, _body::binary>> = rest
+    end
+
+    test "FindCoordinator V3 (flexible) uses int16-prefixed client_id + tag_buffer" do
+      request = %Kayrock.FindCoordinator.V3.Request{
+        key: "my-group",
+        key_type: 0,
+        tagged_fields: [],
+        correlation_id: 1,
+        client_id: "test"
+      }
+
+      serialized = IO.iodata_to_binary(Kayrock.FindCoordinator.V3.Request.serialize(request))
+
+      <<_api_key::16, _api_version::16, _correlation_id::32, rest::binary>> = serialized
+
+      # "test" (4 bytes) -> <<0, 4>> int16 prefix, then "test", then <<0>> tag_buffer
+      assert <<0, 4, "test", 0, _body::binary>> = rest
+    end
+
+    test "ApiVersions V3 (flexible) uses int16-prefixed client_id + tag_buffer" do
+      request = %Kayrock.ApiVersions.V3.Request{
+        client_software_name: "kafka_ex",
+        client_software_version: "1.0.0",
+        tagged_fields: [],
+        correlation_id: 1,
+        client_id: "kafka_ex"
+      }
+
+      serialized = IO.iodata_to_binary(Kayrock.ApiVersions.V3.Request.serialize(request))
+
+      <<_api_key::16, _api_version::16, _correlation_id::32, rest::binary>> = serialized
+
+      # "kafka_ex" (8 bytes) -> <<0, 8>> int16 prefix, then string, then <<0>> tag_buffer
+      assert <<0, 8, "kafka_ex", 0, _body::binary>> = rest
+    end
+
+    test "flexible version with nil client_id serializes as nullable_string null" do
+      request = %Kayrock.Heartbeat.V4.Request{
+        group_id: "test-group",
+        generation_id: 1,
+        member_id: "member-1",
+        group_instance_id: nil,
+        tagged_fields: [],
+        correlation_id: 42,
+        client_id: nil
+      }
+
+      serialized = IO.iodata_to_binary(Kayrock.Heartbeat.V4.Request.serialize(request))
+
+      <<_api_key::16, _api_version::16, _correlation_id::32, rest::binary>> = serialized
+
+      # null client_id: <<255, 255>> (-1 as int16-signed), then <<0>> tag_buffer
+      assert <<255, 255, 0, _body::binary>> = rest
+    end
+  end
+
+  describe "non-flexible request headers (header v1)" do
+    test "Heartbeat V3 (non-flexible) uses int16-prefixed client_id, no tag_buffer" do
+      request = %Kayrock.Heartbeat.V3.Request{
+        group_id: "test-group",
+        generation_id: 1,
+        member_id: "member-1",
+        group_instance_id: nil,
+        correlation_id: 42,
+        client_id: "kafka_ex"
+      }
+
+      serialized = IO.iodata_to_binary(Kayrock.Heartbeat.V3.Request.serialize(request))
+
+      <<_api_key::16, _api_version::16, _correlation_id::32, rest::binary>> = serialized
+
+      # Non-flexible: <<0, 8>> int16 prefix, then "kafka_ex", then body (no tag_buffer)
+      assert <<0, 8, "kafka_ex", _body::binary>> = rest
+    end
+
+    test "non-flexible version with nil client_id serializes as nullable_string null" do
+      request = %Kayrock.Heartbeat.V3.Request{
+        group_id: "test-group",
+        generation_id: 1,
+        member_id: "member-1",
+        group_instance_id: nil,
+        correlation_id: 42,
+        client_id: nil
+      }
+
+      serialized = IO.iodata_to_binary(Kayrock.Heartbeat.V3.Request.serialize(request))
+
+      <<_api_key::16, _api_version::16, _correlation_id::32, rest::binary>> = serialized
+
+      # null client_id: <<255, 255>> (-1 as int16-signed), then body directly (no tag_buffer)
+      assert <<255, 255, _body::binary>> = rest
+    end
+  end
+
+  describe "client_id edge cases" do
+    test "empty string client_id is distinct from nil (flexible)" do
+      base = %Kayrock.Heartbeat.V4.Request{
+        group_id: "g",
+        generation_id: 1,
+        member_id: "m",
+        group_instance_id: nil,
+        tagged_fields: [],
+        correlation_id: 1
+      }
+
+      empty = IO.iodata_to_binary(Kayrock.Heartbeat.V4.Request.serialize(%{base | client_id: ""}))
+      null = IO.iodata_to_binary(Kayrock.Heartbeat.V4.Request.serialize(%{base | client_id: nil}))
+
+      <<_::64, empty_rest::binary>> = empty
+      <<_::64, null_rest::binary>> = null
+
+      # empty string: <<0, 0>> (int16 length = 0), then <<0>> tag_buffer
+      assert <<0, 0, 0, _::binary>> = empty_rest
+      # null: <<255, 255>> (-1 as int16-signed), then <<0>> tag_buffer
+      assert <<255, 255, 0, _::binary>> = null_rest
+
+      # They must differ
+      assert empty != null
+    end
+
+    test "empty string client_id is distinct from nil (non-flexible)" do
+      base = %Kayrock.Heartbeat.V3.Request{
+        group_id: "g",
+        generation_id: 1,
+        member_id: "m",
+        group_instance_id: nil,
+        correlation_id: 1
+      }
+
+      empty = IO.iodata_to_binary(Kayrock.Heartbeat.V3.Request.serialize(%{base | client_id: ""}))
+      null = IO.iodata_to_binary(Kayrock.Heartbeat.V3.Request.serialize(%{base | client_id: nil}))
+
+      <<_::64, empty_rest::binary>> = empty
+      <<_::64, null_rest::binary>> = null
+
+      # empty string: <<0, 0>> (int16 length = 0), then body
+      assert <<0, 0, _::binary>> = empty_rest
+      # null: <<255, 255>> (-1 as int16-signed), then body
+      assert <<255, 255, _::binary>> = null_rest
+
+      assert empty != null
+    end
+  end
+
+  describe "header format consistency across all flexible APIs" do
+    # Every flexible-version request must use int16-prefixed client_id + tag_buffer.
+    # This data-driven test verifies the pattern for all APIs.
+
+    @flexible_requests [
+      {Kayrock.ApiVersions.V3.Request,
+       %{client_software_name: "k", client_software_version: "1", tagged_fields: []}},
+      {Kayrock.Metadata.V9.Request,
+       %{
+         topics: nil,
+         allow_auto_topic_creation: true,
+         include_cluster_authorized_operations: false,
+         include_topic_authorized_operations: false,
+         tagged_fields: []
+       }},
+      {Kayrock.FindCoordinator.V3.Request, %{key: "g", key_type: 0, tagged_fields: []}},
+      {Kayrock.Heartbeat.V4.Request,
+       %{
+         group_id: "g",
+         generation_id: 1,
+         member_id: "m",
+         group_instance_id: nil,
+         tagged_fields: []
+       }},
+      {Kayrock.JoinGroup.V6.Request,
+       %{
+         group_id: "g",
+         session_timeout_ms: 10_000,
+         rebalance_timeout_ms: 5000,
+         member_id: "",
+         protocol_type: "consumer",
+         protocols: [],
+         group_instance_id: nil,
+         tagged_fields: []
+       }},
+      {Kayrock.SyncGroup.V4.Request,
+       %{
+         group_id: "g",
+         generation_id: 1,
+         member_id: "m",
+         group_instance_id: nil,
+         assignments: [],
+         tagged_fields: []
+       }},
+      {Kayrock.LeaveGroup.V4.Request, %{group_id: "g", members: [], tagged_fields: []}},
+      {Kayrock.OffsetFetch.V6.Request, %{group_id: "g", topics: [], tagged_fields: []}},
+      {Kayrock.OffsetCommit.V8.Request,
+       %{
+         group_id: "g",
+         generation_id: 1,
+         member_id: "m",
+         group_instance_id: nil,
+         topics: [],
+         tagged_fields: []
+       }},
+      {Kayrock.DescribeGroups.V5.Request,
+       %{groups: [], include_authorized_operations: false, tagged_fields: []}},
+      {Kayrock.CreateTopics.V5.Request,
+       %{topics: [], timeout_ms: 5000, validate_only: false, tagged_fields: []}},
+      {Kayrock.DeleteTopics.V4.Request, %{topic_names: [], timeout_ms: 5000, tagged_fields: []}}
+    ]
+
+    for {mod, fields} <- @flexible_requests do
+      api_name = mod |> Module.split() |> Enum.at(1)
+      version = mod |> Module.split() |> Enum.at(2) |> String.trim_leading("V")
+
+      test "#{api_name} V#{version} uses int16 client_id + tag_buffer" do
+        mod = unquote(mod)
+
+        request =
+          struct(
+            mod,
+            Map.merge(unquote(Macro.escape(fields)), %{
+              correlation_id: 1,
+              client_id: "cid"
+            })
+          )
+
+        serialized = IO.iodata_to_binary(mod.serialize(request))
+
+        <<_api_key::16, _api_version::16, _correlation_id::32, rest::binary>> = serialized
+
+        # All flexible requests: int16 prefix for "cid" (3 bytes) = <<0, 3>>, then "cid", then <<0>>
+        assert <<0, 3, "cid", 0, _body::binary>> = rest
+      end
+    end
+  end
+
+  describe "ApiVersionsResponse V3 header exception (KIP-511)" do
+    test "V3 response deserializes without header tag_buffer" do
+      # ApiVersionsResponse ALWAYS uses response header v0 (just correlation_id).
+      # The body uses flexible encoding (compact arrays, tagged fields).
+      response_binary =
+        <<
+          # correlation_id
+          0,
+          0,
+          0,
+          42,
+          # error_code (0 = no error)
+          0,
+          0,
+          # api_keys compact_array: varint(2+1) = 3, then 2 entries
+          3,
+          # Entry 1: Produce api_key=0, min=0, max=9
+          0,
+          0,
+          0,
+          0,
+          0,
+          9,
+          # entry tagged_fields
+          0,
+          # Entry 2: Fetch api_key=1, min=0, max=13
+          0,
+          1,
+          0,
+          0,
+          0,
+          13,
+          # entry tagged_fields
+          0,
+          # throttle_time_ms
+          0,
+          0,
+          0,
+          0,
+          # response body tagged_fields
+          0
+        >>
+
+      {response, <<>>} = Kayrock.ApiVersions.V3.Response.deserialize(response_binary)
+
+      assert response.correlation_id == 42
+      assert response.error_code == 0
+      assert length(response.api_keys) == 2
+      assert hd(response.api_keys).api_key == 0
+    end
+
+    test "V2 response (non-flexible) still works unchanged" do
+      {binary, expected} = Kayrock.Test.Factories.ApiVersionsFactory.response_data(2)
+      {actual, <<>>} = Kayrock.ApiVersions.V2.Response.deserialize(binary)
+      assert actual == expected
+    end
+  end
+end

--- a/test/kayrock/generated/heartbeat_test.exs
+++ b/test/kayrock/generated/heartbeat_test.exs
@@ -107,11 +107,11 @@ defmodule Kayrock.HeartbeatTest do
         0,
         0,
         4,
-        # client_id
+        # client_id (int16-prefixed nullable_string)
         0,
         4,
         "test"::binary,
-        # flexible header marker (tagged fields)
+        # flexible header tag_buffer
         0,
         # group_id (compact string: length+1 = 6)
         6,

--- a/test/kayrock/generated/leave_group_test.exs
+++ b/test/kayrock/generated/leave_group_test.exs
@@ -143,8 +143,8 @@ defmodule Kayrock.LeaveGroupTest do
       }
 
       serialized = IO.iodata_to_binary(Kayrock.Request.serialize(request))
-      # After header, client_id, flexible marker: compact string "abc" = length+1 then bytes
-      # group_id starts at position: 2+2+4+2+4+1 = 15
+      # After header: api_key(2) + api_version(2) + correlation_id(4) +
+      # int16-prefixed client_id (2 prefix + "test"=4 = 6) + tag_buffer(1) = 15
       <<_header::15-binary, group_id_length, "abc", _rest::binary>> = serialized
       # length("abc") + 1
       assert group_id_length == 4

--- a/test/sanity/admin_sanity_test.exs
+++ b/test/sanity/admin_sanity_test.exs
@@ -60,7 +60,6 @@ defmodule Kayrock.Sanity.AdminSanityTest do
 
       assert is_list(response.resources),
              "V0 resources should be a list"
-
     end
 
     # V1: adds resource_pattern_type_filter
@@ -88,7 +87,6 @@ defmodule Kayrock.Sanity.AdminSanityTest do
 
       assert is_list(response.resources),
              "V1 resources should be a list"
-
     end
 
     @tag api: :describe_acls

--- a/test/sanity/admin_sanity_test.exs
+++ b/test/sanity/admin_sanity_test.exs
@@ -1,0 +1,995 @@
+defmodule Kayrock.Sanity.AdminSanityTest do
+  @moduledoc """
+  Sanity tests for admin APIs — only a broker connection and a test topic required.
+
+  Covers:
+  - DescribeAcls V0-V1 (API key 29)
+  - CreateAcls V0-V1 (API key 30)
+  - DeleteAcls V0-V1 (API key 31)
+  - AlterReplicaLogDirs V0-V1 (API key 34)
+  - DescribeLogDirs V0-V1 (API key 35)
+  - CreateDelegationToken V0-V2 (API key 38) — expects error 61 or 64 (tokens disabled/not allowed)
+  - RenewDelegationToken V0-V1 (API key 39) — expects error 61, 64, or 2
+  - ExpireDelegationToken V0-V1 (API key 40) — expects error 61, 64, or 2
+  - DescribeDelegationToken V0-V1 (API key 41) — expects error 61 or 64
+  - ElectLeaders V0-V2 (API key 43)
+  - AlterPartitionReassignments V0 (API key 45)
+  - ListPartitionReassignments V0 (API key 46)
+
+  Run with:
+      mix test.sanity test/sanity/admin_sanity_test.exs
+  """
+  use Kayrock.SanityCase
+  use ExUnit.Case, async: false
+
+  container(:kafka, KafkaContainer.new(), shared: true)
+
+  setup_all %{kafka: kafka} do
+    {:ok, client} = build_client(kafka)
+    topic = create_topic(client, 5)
+    :ok = wait_for_topic(client, topic)
+    %{client: client, topic: topic}
+  end
+
+  # ---------------------------------------------------------------------------
+  # DescribeAcls V0-V1 (API key 29)
+  # ---------------------------------------------------------------------------
+
+  describe "DescribeAcls" do
+    # V0: no resource_pattern_type_filter field
+    @tag api: :describe_acls, version: 0
+    test "V0 returns parseable response (no resource_pattern_type_filter)", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.DescribeAcls.V0.Request{
+        resource_type: 2,
+        resource_name: nil,
+        principal: "User:test-sanity",
+        host: nil,
+        operation: 1,
+        permission_type: 1
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_integer(response.throttle_time_ms),
+             "V0 throttle_time_ms should be integer"
+
+      assert is_integer(response.error_code),
+             "V0 error_code should be integer"
+
+      assert is_list(response.resources),
+             "V0 resources should be a list"
+
+      assert is_integer(response.correlation_id),
+             "V0 correlation_id should be integer"
+    end
+
+    # V1: adds resource_pattern_type_filter
+    @tag api: :describe_acls, version: 1
+    test "V1 returns parseable response (with resource_pattern_type_filter)", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.DescribeAcls.V1.Request{
+        resource_type: 2,
+        resource_name: nil,
+        resource_pattern_type_filter: 3,
+        principal: "User:test-sanity",
+        host: nil,
+        operation: 1,
+        permission_type: 1
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_integer(response.throttle_time_ms),
+             "V1 throttle_time_ms should be integer"
+
+      assert is_integer(response.error_code),
+             "V1 error_code should be integer"
+
+      assert is_list(response.resources),
+             "V1 resources should be a list"
+
+      assert is_integer(response.correlation_id),
+             "V1 correlation_id should be integer"
+    end
+
+    @tag api: :describe_acls
+    test "V0 response does not have resource_pattern_type_filter field (correct version)", %{
+      kafka: kafka
+    } do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.DescribeAcls.V0.Request{
+        resource_type: 1,
+        resource_name: nil,
+        principal: nil,
+        host: nil,
+        operation: 1,
+        permission_type: 1
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      # V0 response should not have resource_pattern_type on top-level
+      refute Map.has_key?(response, :resource_pattern_type_filter),
+             "V0 response should not have resource_pattern_type_filter field"
+    end
+
+    @tag api: :describe_acls
+    test "V1 returns empty resources list for non-existent principal", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.DescribeAcls.V1.Request{
+        resource_type: 2,
+        resource_name: "does-not-exist-topic",
+        resource_pattern_type_filter: 3,
+        principal: "User:nonexistent-test-sanity",
+        host: "*",
+        operation: 2,
+        permission_type: 3
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      # Accept 0 (success, empty list) or auth error codes
+      # 54 = CLUSTER_AUTHORIZATION_FAILED (broker may enforce stricter auth with V1 pattern type filter)
+      assert response.error_code in [0, 29, 31, 54],
+             "Expected success or auth error, got #{response.error_code}"
+
+      if response.error_code == 0 do
+        assert response.resources == [],
+               "V1 non-existent principal should return empty resources list"
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # CreateAcls V0-V1 (API key 30)
+  # ---------------------------------------------------------------------------
+
+  describe "CreateAcls" do
+    # V0: creation entry without resource_pattern_type
+    @tag api: :create_acls, version: 0
+    test "V0 accepts valid creation entry and returns parseable response", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      creation = %{
+        resource_type: 2,
+        resource_name: "test-sanity-topic",
+        principal: "User:test-sanity",
+        host: "*",
+        operation: 2,
+        permission_type: 3
+      }
+
+      request = %Kayrock.CreateAcls.V0.Request{creations: [creation]}
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_integer(response.throttle_time_ms),
+             "V0 throttle_time_ms should be integer"
+
+      assert is_list(response.creation_responses),
+             "V0 creation_responses should be a list"
+
+      assert is_integer(response.correlation_id),
+             "V0 correlation_id should be integer"
+
+      # Each creation response has error_code
+      for cr <- response.creation_responses do
+        assert is_integer(cr.error_code),
+               "V0 creation_response error_code should be integer"
+      end
+    end
+
+    # V1: creation entry with resource_pattern_type
+    @tag api: :create_acls, version: 1
+    test "V1 accepts creation entry with resource_pattern_type and returns parseable response",
+         %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      creation = %{
+        resource_type: 2,
+        resource_name: "test-sanity-topic",
+        resource_pattern_type: 3,
+        principal: "User:test-sanity",
+        host: "*",
+        operation: 2,
+        permission_type: 3
+      }
+
+      request = %Kayrock.CreateAcls.V1.Request{creations: [creation]}
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_integer(response.throttle_time_ms),
+             "V1 throttle_time_ms should be integer"
+
+      assert is_list(response.creation_responses),
+             "V1 creation_responses (not 'results') should be a list"
+
+      for cr <- response.creation_responses do
+        assert is_integer(cr.error_code),
+               "V1 creation_response error_code should be integer"
+      end
+    end
+
+    @tag api: :create_acls
+    test "V0 empty creations list is accepted", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      request = %Kayrock.CreateAcls.V0.Request{creations: []}
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert response.creation_responses == [],
+             "V0 empty creations should return empty creation_responses"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # DeleteAcls V0-V1 (API key 31)
+  # ---------------------------------------------------------------------------
+
+  describe "DeleteAcls" do
+    # V0: filter without resource_pattern_type_filter
+    @tag api: :delete_acls, version: 0
+    test "V0 accepts valid filter and returns parseable response", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      filter = %{
+        resource_type: 1,
+        resource_name: nil,
+        principal: "User:test-sanity",
+        host: "*",
+        operation: 1,
+        permission_type: 1
+      }
+
+      request = %Kayrock.DeleteAcls.V0.Request{filters: [filter]}
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_integer(response.throttle_time_ms),
+             "V0 throttle_time_ms should be integer"
+
+      assert is_list(response.filter_responses),
+             "V0 filter_responses (not 'filter_results') should be a list"
+
+      assert is_integer(response.correlation_id),
+             "V0 correlation_id should be integer"
+
+      for fr <- response.filter_responses do
+        assert is_integer(fr.error_code),
+               "V0 filter_response error_code should be integer"
+      end
+    end
+
+    # V1: filter with resource_pattern_type_filter
+    @tag api: :delete_acls, version: 1
+    test "V1 accepts filter with resource_pattern_type_filter and returns parseable response",
+         %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      filter = %{
+        resource_type: 1,
+        resource_name: nil,
+        resource_pattern_type_filter: 3,
+        principal: "User:test-sanity",
+        host: "*",
+        operation: 1,
+        permission_type: 1
+      }
+
+      request = %Kayrock.DeleteAcls.V1.Request{filters: [filter]}
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_integer(response.throttle_time_ms),
+             "V1 throttle_time_ms should be integer"
+
+      assert is_list(response.filter_responses),
+             "V1 filter_responses (not 'filter_results') should be a list"
+
+      for fr <- response.filter_responses do
+        assert is_integer(fr.error_code),
+               "V1 filter_response error_code should be integer"
+      end
+    end
+
+    @tag api: :delete_acls
+    test "V0 empty filters list is accepted", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      request = %Kayrock.DeleteAcls.V0.Request{filters: []}
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert response.filter_responses == [],
+             "V0 empty filters should return empty filter_responses"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # DescribeLogDirs V0-V1 (API key 35)
+  # ---------------------------------------------------------------------------
+
+  describe "DescribeLogDirs" do
+    for version <- 0..1 do
+      @tag api: :describe_log_dirs, version: version
+      test "V#{version} with specific topic returns parseable response", %{
+        kafka: kafka,
+        topic: topic
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request =
+          version
+          |> Kayrock.DescribeLogDirs.get_request_struct()
+          |> Map.put(:topics, [%{topic: topic, partitions: [0]}])
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert is_list(response.log_dirs),
+               "V#{version} log_dirs (not 'results') should be a list"
+
+        assert is_integer(response.correlation_id),
+               "V#{version} correlation_id should be integer"
+      end
+
+      @tag api: :describe_log_dirs, version: version
+      test "V#{version} with nil topics (all log dirs) returns parseable response", %{
+        kafka: kafka
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request =
+          version
+          |> Kayrock.DescribeLogDirs.get_request_struct()
+          |> Map.put(:topics, nil)
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert is_list(response.log_dirs),
+               "V#{version} log_dirs should be a list"
+
+        # At least one log dir entry expected for a running broker
+        assert response.log_dirs != [],
+               "V#{version} broker should report at least one log dir"
+
+        for ld <- response.log_dirs do
+          assert is_integer(ld.error_code),
+                 "V#{version}: log_dir.error_code should be integer"
+
+          assert is_binary(ld.log_dir),
+                 "V#{version}: log_dir.log_dir should be binary"
+
+          assert is_list(ld.topics),
+                 "V#{version}: log_dir.topics should be a list"
+        end
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AlterReplicaLogDirs V0-V1 (API key 34)
+  # ---------------------------------------------------------------------------
+
+  describe "AlterReplicaLogDirs" do
+    for version <- 0..1 do
+      @tag api: :alter_replica_log_dirs, version: version
+      test "V#{version} with non-existent path returns parseable response (partition error expected)",
+           %{kafka: kafka, topic: topic} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        # Request to move a partition to a non-existent path — broker will respond
+        # with per-partition error (LOG_DIR_NOT_FOUND = 57 or similar) but will
+        # not TCP-disconnect, so we can verify the response struct is valid.
+        request =
+          version
+          |> Kayrock.AlterReplicaLogDirs.get_request_struct()
+          |> Map.put(:log_dirs, [
+            %{
+              log_dir: "/non/existent/path",
+              topics: [%{topic: topic, partitions: [0]}]
+            }
+          ])
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert is_list(response.topics),
+               "V#{version} topics (not 'results') should be a list"
+
+        assert is_integer(response.correlation_id),
+               "V#{version} correlation_id should be integer"
+
+        for t <- response.topics do
+          assert is_binary(t.topic), "V#{version}: topic.topic should be binary"
+          assert is_list(t.partitions), "V#{version}: topic.partitions should be a list"
+
+          for p <- t.partitions do
+            assert is_integer(p.error_code),
+                   "V#{version}: partition.error_code should be integer"
+          end
+        end
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # CreateDelegationToken V0-V2 (API key 38)
+  # Expects error 61 (DELEGATION_TOKEN_AUTH_DISABLED) in default broker config
+  # ---------------------------------------------------------------------------
+
+  describe "CreateDelegationToken" do
+    # V0 and V1 have the same schema
+    for version <- 0..1 do
+      @tag api: :create_delegation_token, version: version
+      test "V#{version} returns parseable response (error 61 expected for disabled tokens)",
+           %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request =
+          version
+          |> Kayrock.CreateDelegationToken.get_request_struct()
+          |> Map.put(:renewers, [])
+          |> Map.put(:max_lifetime_ms, -1)
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        # error_code 61 = DELEGATION_TOKEN_AUTH_DISABLED (expected in default config)
+        # error_code 64 = DELEGATION_TOKEN_REQUEST_NOT_ALLOWED (broker rejects without specific auth config)
+        assert response.error_code in [0, 61, 64],
+               "V#{version} expected error_code 0, 61, or 64 (tokens disabled/not allowed), got #{response.error_code}"
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert is_integer(response.correlation_id),
+               "V#{version} correlation_id should be integer"
+      end
+    end
+
+    # V2: flexible version adds tagged_fields
+    @tag api: :create_delegation_token, version: 2
+    test "V2 returns parseable response with tagged_fields support (error 61 expected)",
+         %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.CreateDelegationToken.V2.Request{
+        renewers: [],
+        max_lifetime_ms: -1,
+        tagged_fields: []
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      # 64 = DELEGATION_TOKEN_REQUEST_NOT_ALLOWED (broker rejects without specific auth config)
+      assert response.error_code in [0, 61, 64],
+             "V2 expected error_code 0, 61, or 64 (tokens disabled/not allowed), got #{response.error_code}"
+
+      assert is_integer(response.throttle_time_ms),
+             "V2 throttle_time_ms should be integer"
+
+      assert is_integer(response.correlation_id),
+             "V2 correlation_id should be integer"
+    end
+
+    @tag api: :create_delegation_token
+    test "V0 response has required fields", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.CreateDelegationToken.V0.Request{
+        renewers: [],
+        max_lifetime_ms: -1
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert Map.has_key?(response, :error_code), "response must have error_code"
+      assert Map.has_key?(response, :principal_type), "response must have principal_type"
+      assert Map.has_key?(response, :principal_name), "response must have principal_name"
+      assert Map.has_key?(response, :issue_timestamp_ms), "response must have issue_timestamp_ms"
+
+      assert Map.has_key?(response, :expiry_timestamp_ms),
+             "response must have expiry_timestamp_ms"
+
+      assert Map.has_key?(response, :max_timestamp_ms), "response must have max_timestamp_ms"
+      assert Map.has_key?(response, :token_id), "response must have token_id"
+      assert Map.has_key?(response, :hmac), "response must have hmac"
+      assert Map.has_key?(response, :throttle_time_ms), "response must have throttle_time_ms"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # RenewDelegationToken V0-V1 (API key 39)
+  # Expects error 61 (tokens disabled) or 2 (token not found)
+  # ---------------------------------------------------------------------------
+
+  describe "RenewDelegationToken" do
+    for version <- 0..1 do
+      @tag api: :renew_delegation_token, version: version
+      test "V#{version} returns parseable response (expects error 61 or 2)", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request =
+          version
+          |> Kayrock.RenewDelegationToken.get_request_struct()
+          |> Map.put(:hmac, <<0, 1, 2, 3>>)
+          |> Map.put(:renew_period_ms, 86_400_000)
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        # 61 = DELEGATION_TOKEN_AUTH_DISABLED, 2 = CORRUPT_MESSAGE / token not found
+        # 64 = DELEGATION_TOKEN_REQUEST_NOT_ALLOWED (broker rejects without specific auth config)
+        assert is_integer(response.error_code),
+               "V#{version} error_code should be integer"
+
+        assert response.error_code in [0, 2, 61, 64],
+               "V#{version} expected 0, 2, 61, or 64, got #{response.error_code}"
+
+        assert is_integer(response.expiry_timestamp_ms),
+               "V#{version} expiry_timestamp_ms should be integer"
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert is_integer(response.correlation_id),
+               "V#{version} correlation_id should be integer"
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # ExpireDelegationToken V0-V1 (API key 40)
+  # Expects error 61 (tokens disabled) or 2 (token not found)
+  # ---------------------------------------------------------------------------
+
+  describe "ExpireDelegationToken" do
+    for version <- 0..1 do
+      @tag api: :expire_delegation_token, version: version
+      test "V#{version} returns parseable response (expects error 61 or 2)", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request =
+          version
+          |> Kayrock.ExpireDelegationToken.get_request_struct()
+          |> Map.put(:hmac, <<0, 1, 2, 3>>)
+          |> Map.put(:expiry_time_period_ms, -1)
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.error_code),
+               "V#{version} error_code should be integer"
+
+        # 64 = DELEGATION_TOKEN_REQUEST_NOT_ALLOWED (broker rejects without specific auth config)
+        assert response.error_code in [0, 2, 61, 64],
+               "V#{version} expected 0, 2, 61, or 64, got #{response.error_code}"
+
+        assert is_integer(response.expiry_timestamp_ms),
+               "V#{version} expiry_timestamp_ms should be integer"
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert is_integer(response.correlation_id),
+               "V#{version} correlation_id should be integer"
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # DescribeDelegationToken V0-V1 (API key 41)
+  # Expects error 61 (DELEGATION_TOKEN_AUTH_DISABLED) in default broker config
+  # ---------------------------------------------------------------------------
+
+  describe "DescribeDelegationToken" do
+    # Empty owners list = describe all tokens
+    for version <- 0..1 do
+      @tag api: :describe_delegation_token, version: version
+      test "V#{version} empty owners list returns parseable response (error 61 expected)",
+           %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request =
+          version
+          |> Kayrock.DescribeDelegationToken.get_request_struct()
+          |> Map.put(:owners, [])
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.error_code),
+               "V#{version} error_code should be integer"
+
+        # 61 = DELEGATION_TOKEN_AUTH_DISABLED
+        # 64 = DELEGATION_TOKEN_REQUEST_NOT_ALLOWED (broker rejects without specific auth config)
+        assert response.error_code in [0, 61, 64],
+               "V#{version} expected error_code 0, 61, or 64, got #{response.error_code}"
+
+        assert is_list(response.tokens),
+               "V#{version} tokens should be a list"
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert is_integer(response.correlation_id),
+               "V#{version} correlation_id should be integer"
+      end
+    end
+
+    @tag api: :describe_delegation_token
+    test "V0 response struct has correct field order (error_code before tokens before throttle_time_ms)",
+         %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.DescribeDelegationToken.V0.Request{owners: []}
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      # Verify the struct has the correct fields per the schema:
+      # error_code, tokens, throttle_time_ms
+      assert Map.has_key?(response, :error_code), "response must have error_code"
+      assert Map.has_key?(response, :tokens), "response must have tokens"
+      assert Map.has_key?(response, :throttle_time_ms), "response must have throttle_time_ms"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # ElectLeaders V0-V2 (API key 43)
+  # ---------------------------------------------------------------------------
+
+  describe "ElectLeaders" do
+    # V0 has NO election_type field (added in V1 per KIP-460)
+    @tag api: :elect_leaders, version: 0
+    test "V0 (no election_type field) with existing topic partition returns parseable response",
+         %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+
+      # V0.Request: fields are topic_partitions and timeout_ms (NO election_type)
+      request = %Kayrock.ElectLeaders.V0.Request{
+        topic_partitions: [%{topic: topic, partition_id: [0]}],
+        timeout_ms: 5000
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_integer(response.throttle_time_ms),
+             "V0 throttle_time_ms should be integer"
+
+      assert is_list(response.replica_election_results),
+             "V0 replica_election_results should be a list"
+
+      assert is_integer(response.correlation_id),
+             "V0 correlation_id should be integer"
+    end
+
+    @tag api: :elect_leaders, version: 0
+    test "V0 does not have election_type field in request struct" do
+      request = Kayrock.ElectLeaders.get_request_struct(0)
+
+      refute Map.has_key?(request, :election_type),
+             "V0 ElectLeaders request should NOT have election_type (added in V1)"
+    end
+
+    # V1 adds election_type
+    @tag api: :elect_leaders, version: 1
+    test "V1 (with election_type) with existing topic partition returns parseable response",
+         %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.ElectLeaders.V1.Request{
+        election_type: 0,
+        topic_partitions: [%{topic: topic, partition_id: [0]}],
+        timeout_ms: 5000
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_integer(response.throttle_time_ms),
+             "V1 throttle_time_ms should be integer"
+
+      # V1+ response also has top-level error_code
+      assert is_integer(response.error_code),
+             "V1 error_code should be integer"
+
+      assert is_list(response.replica_election_results),
+             "V1 replica_election_results should be a list"
+    end
+
+    # V2 is flexible version (tagged_fields)
+    @tag api: :elect_leaders, version: 2
+    test "V2 (flexible, tagged_fields) with existing topic partition returns parseable response",
+         %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.ElectLeaders.V2.Request{
+        election_type: 0,
+        topic_partitions: [
+          %{
+            topic: topic,
+            partition_id: [0],
+            tagged_fields: []
+          }
+        ],
+        timeout_ms: 5000,
+        tagged_fields: []
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_integer(response.throttle_time_ms),
+             "V2 throttle_time_ms should be integer"
+
+      assert is_integer(response.error_code),
+             "V2 error_code should be integer"
+
+      assert is_list(response.replica_election_results),
+             "V2 replica_election_results should be a list"
+    end
+
+    @tag api: :elect_leaders
+    test "V0 replica_election_results entries have correct structure when partitions listed",
+         %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.ElectLeaders.V0.Request{
+        topic_partitions: [%{topic: topic, partition_id: [0]}],
+        timeout_ms: 5000
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      for r <- response.replica_election_results do
+        assert is_binary(r.topic), "replica_election_result.topic should be binary"
+
+        assert is_list(r.partition_result),
+               "replica_election_result.partition_result should be list"
+
+        for p <- r.partition_result do
+          assert is_integer(p.partition_id), "partition_result.partition_id should be integer"
+          assert is_integer(p.error_code), "partition_result.error_code should be integer"
+        end
+      end
+    end
+
+    @tag api: :elect_leaders
+    test "V0 with empty topic_partitions is accepted", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.ElectLeaders.V0.Request{
+        topic_partitions: [],
+        timeout_ms: 5000
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_list(response.replica_election_results),
+             "empty topic_partitions should return empty replica_election_results"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AlterPartitionReassignments V0 (API key 45) — flexible version
+  # ---------------------------------------------------------------------------
+
+  describe "AlterPartitionReassignments" do
+    @tag api: :alter_partition_reassignments, version: 0
+    test "V0 with nil replicas (cancel reassignment) returns parseable response",
+         %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+
+      # nil replicas = cancel any ongoing reassignment for that partition
+      request = %Kayrock.AlterPartitionReassignments.V0.Request{
+        timeout_ms: 5000,
+        topics: [
+          %{
+            name: topic,
+            partitions: [
+              %{partition_index: 0, replicas: nil, tagged_fields: []}
+            ],
+            tagged_fields: []
+          }
+        ],
+        tagged_fields: []
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_integer(response.throttle_time_ms),
+             "V0 throttle_time_ms should be integer"
+
+      assert is_integer(response.error_code),
+             "V0 error_code should be integer"
+
+      # 0 = success, 37 = INVALID_REPLICA_ASSIGNMENT (no ongoing reassignment to cancel)
+      assert response.error_code in [0, 37],
+             "V0 expected 0 or 37, got #{response.error_code}"
+
+      assert is_list(response.responses),
+             "V0 responses should be a list"
+
+      assert is_list(response.tagged_fields),
+             "V0 tagged_fields should be a list (flexible version)"
+
+      assert is_integer(response.correlation_id),
+             "V0 correlation_id should be integer"
+    end
+
+    @tag api: :alter_partition_reassignments, version: 0
+    test "V0 with empty topics list is accepted", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.AlterPartitionReassignments.V0.Request{
+        timeout_ms: 5000,
+        topics: [],
+        tagged_fields: []
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_integer(response.throttle_time_ms),
+             "V0 empty topics: throttle_time_ms should be integer"
+
+      assert response.responses == [],
+             "V0 empty topics should return empty responses"
+    end
+
+    @tag api: :alter_partition_reassignments
+    test "V0 response has tagged_fields (flexible version check)", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.AlterPartitionReassignments.V0.Request{
+        timeout_ms: 1000,
+        topics: [],
+        tagged_fields: []
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_list(response.tagged_fields),
+             "V0 AlterPartitionReassignments response.tagged_fields should be a list"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # ListPartitionReassignments V0 (API key 46) — flexible version
+  # ---------------------------------------------------------------------------
+
+  describe "ListPartitionReassignments" do
+    @tag api: :list_partition_reassignments, version: 0
+    test "V0 with specific topic returns parseable response", %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.ListPartitionReassignments.V0.Request{
+        timeout_ms: 5000,
+        topics: [
+          %{
+            name: topic,
+            partition_indexes: [0],
+            tagged_fields: []
+          }
+        ],
+        tagged_fields: []
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_integer(response.throttle_time_ms),
+             "V0 throttle_time_ms should be integer"
+
+      assert is_integer(response.error_code),
+             "V0 error_code should be integer"
+
+      assert response.error_code == 0,
+             "V0 list reassignments expected error_code 0, got #{response.error_code}"
+
+      assert is_list(response.topics),
+             "V0 topics (not 'results') should be a list"
+
+      assert is_list(response.tagged_fields),
+             "V0 tagged_fields should be a list (flexible version)"
+
+      assert is_integer(response.correlation_id),
+             "V0 correlation_id should be integer"
+    end
+
+    @tag api: :list_partition_reassignments, version: 0
+    test "V0 with nil topics (all reassignments) returns parseable response", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.ListPartitionReassignments.V0.Request{
+        timeout_ms: 5000,
+        topics: nil,
+        tagged_fields: []
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_integer(response.error_code),
+             "V0 nil topics: error_code should be integer"
+
+      assert response.error_code == 0,
+             "V0 nil topics expected 0, got #{response.error_code}"
+
+      assert is_list(response.topics),
+             "V0 nil topics: response.topics should be a list"
+    end
+
+    @tag api: :list_partition_reassignments, version: 0
+    test "V0 with empty topics list is accepted (returns all active reassignments)",
+         %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.ListPartitionReassignments.V0.Request{
+        timeout_ms: 5000,
+        topics: [],
+        tagged_fields: []
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_list(response.topics),
+             "V0 empty topics list: response.topics should be a list"
+
+      assert response.error_code == 0,
+             "V0 empty topics expected 0, got #{response.error_code}"
+    end
+
+    @tag api: :list_partition_reassignments
+    test "V0 response has tagged_fields (flexible version check)", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.ListPartitionReassignments.V0.Request{
+        timeout_ms: 1000,
+        topics: nil,
+        tagged_fields: []
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_list(response.tagged_fields),
+             "V0 ListPartitionReassignments response.tagged_fields should be a list"
+    end
+
+    @tag api: :list_partition_reassignments
+    test "V0 topics entries have correct structure when reassignments listed", %{
+      kafka: kafka,
+      topic: topic
+    } do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.ListPartitionReassignments.V0.Request{
+        timeout_ms: 5000,
+        topics: [
+          %{name: topic, partition_indexes: [0], tagged_fields: []}
+        ],
+        tagged_fields: []
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      # No active reassignments expected, but structure must be correct if any
+      for t <- response.topics do
+        assert is_binary(t.name), "topic.name should be binary"
+        assert is_list(t.partitions), "topic.partitions should be a list"
+
+        for p <- t.partitions do
+          assert is_integer(p.partition_index),
+                 "partition.partition_index should be integer"
+
+          assert is_list(p.replicas),
+                 "partition.replicas should be a list"
+        end
+      end
+    end
+  end
+end

--- a/test/sanity/admin_sanity_test.exs
+++ b/test/sanity/admin_sanity_test.exs
@@ -61,8 +61,6 @@ defmodule Kayrock.Sanity.AdminSanityTest do
       assert is_list(response.resources),
              "V0 resources should be a list"
 
-      assert is_integer(response.correlation_id),
-             "V0 correlation_id should be integer"
     end
 
     # V1: adds resource_pattern_type_filter
@@ -91,8 +89,6 @@ defmodule Kayrock.Sanity.AdminSanityTest do
       assert is_list(response.resources),
              "V1 resources should be a list"
 
-      assert is_integer(response.correlation_id),
-             "V1 correlation_id should be integer"
     end
 
     @tag api: :describe_acls
@@ -173,9 +169,6 @@ defmodule Kayrock.Sanity.AdminSanityTest do
       assert is_list(response.creation_responses),
              "V0 creation_responses should be a list"
 
-      assert is_integer(response.correlation_id),
-             "V0 correlation_id should be integer"
-
       # Each creation response has error_code
       for cr <- response.creation_responses do
         assert is_integer(cr.error_code),
@@ -253,9 +246,6 @@ defmodule Kayrock.Sanity.AdminSanityTest do
       assert is_list(response.filter_responses),
              "V0 filter_responses (not 'filter_results') should be a list"
 
-      assert is_integer(response.correlation_id),
-             "V0 correlation_id should be integer"
-
       for fr <- response.filter_responses do
         assert is_integer(fr.error_code),
                "V0 filter_response error_code should be integer"
@@ -330,9 +320,6 @@ defmodule Kayrock.Sanity.AdminSanityTest do
 
         assert is_list(response.log_dirs),
                "V#{version} log_dirs (not 'results') should be a list"
-
-        assert is_integer(response.correlation_id),
-               "V#{version} correlation_id should be integer"
       end
 
       @tag api: :describe_log_dirs, version: version
@@ -406,9 +393,6 @@ defmodule Kayrock.Sanity.AdminSanityTest do
         assert is_list(response.topics),
                "V#{version} topics (not 'results') should be a list"
 
-        assert is_integer(response.correlation_id),
-               "V#{version} correlation_id should be integer"
-
         for t <- response.topics do
           assert is_binary(t.topic), "V#{version}: topic.topic should be binary"
           assert is_list(t.partitions), "V#{version}: topic.partitions should be a list"
@@ -451,9 +435,6 @@ defmodule Kayrock.Sanity.AdminSanityTest do
 
         assert is_integer(response.throttle_time_ms),
                "V#{version} throttle_time_ms should be integer"
-
-        assert is_integer(response.correlation_id),
-               "V#{version} correlation_id should be integer"
       end
     end
 
@@ -477,9 +458,6 @@ defmodule Kayrock.Sanity.AdminSanityTest do
 
       assert is_integer(response.throttle_time_ms),
              "V2 throttle_time_ms should be integer"
-
-      assert is_integer(response.correlation_id),
-             "V2 correlation_id should be integer"
     end
 
     @tag api: :create_delegation_token
@@ -541,9 +519,6 @@ defmodule Kayrock.Sanity.AdminSanityTest do
 
         assert is_integer(response.throttle_time_ms),
                "V#{version} throttle_time_ms should be integer"
-
-        assert is_integer(response.correlation_id),
-               "V#{version} correlation_id should be integer"
       end
     end
   end
@@ -580,9 +555,6 @@ defmodule Kayrock.Sanity.AdminSanityTest do
 
         assert is_integer(response.throttle_time_ms),
                "V#{version} throttle_time_ms should be integer"
-
-        assert is_integer(response.correlation_id),
-               "V#{version} correlation_id should be integer"
       end
     end
   end
@@ -621,9 +593,6 @@ defmodule Kayrock.Sanity.AdminSanityTest do
 
         assert is_integer(response.throttle_time_ms),
                "V#{version} throttle_time_ms should be integer"
-
-        assert is_integer(response.correlation_id),
-               "V#{version} correlation_id should be integer"
       end
     end
 
@@ -667,17 +636,6 @@ defmodule Kayrock.Sanity.AdminSanityTest do
 
       assert is_list(response.replica_election_results),
              "V0 replica_election_results should be a list"
-
-      assert is_integer(response.correlation_id),
-             "V0 correlation_id should be integer"
-    end
-
-    @tag api: :elect_leaders, version: 0
-    test "V0 does not have election_type field in request struct" do
-      request = Kayrock.ElectLeaders.get_request_struct(0)
-
-      refute Map.has_key?(request, :election_type),
-             "V0 ElectLeaders request should NOT have election_type (added in V1)"
     end
 
     # V1 adds election_type
@@ -819,9 +777,6 @@ defmodule Kayrock.Sanity.AdminSanityTest do
 
       assert is_list(response.tagged_fields),
              "V0 tagged_fields should be a list (flexible version)"
-
-      assert is_integer(response.correlation_id),
-             "V0 correlation_id should be integer"
     end
 
     @tag api: :alter_partition_reassignments, version: 0
@@ -897,9 +852,6 @@ defmodule Kayrock.Sanity.AdminSanityTest do
 
       assert is_list(response.tagged_fields),
              "V0 tagged_fields should be a list (flexible version)"
-
-      assert is_integer(response.correlation_id),
-             "V0 correlation_id should be integer"
     end
 
     @tag api: :list_partition_reassignments, version: 0

--- a/test/sanity/consumer_group_sanity_test.exs
+++ b/test/sanity/consumer_group_sanity_test.exs
@@ -1,0 +1,1222 @@
+defmodule Kayrock.Sanity.ConsumerGroupSanityTest do
+  @moduledoc """
+  Sanity tests for consumer group APIs.
+
+  Covers:
+  - FindCoordinator V0-V3 (API key 10)
+  - JoinGroup V0-V6 (API key 11)
+  - SyncGroup V0-V4 (API key 14)
+  - Heartbeat V0-V4 (API key 12)
+  - LeaveGroup V0-V4 (API key 13)
+  - DescribeGroups V0-V5 (API key 15)
+  - OffsetCommit V0-V8 (API key 8)
+  - OffsetFetch V0-V6 (API key 9)
+  - DeleteGroups V0-V2 (API key 42)
+  - OffsetDelete V0 (API key 47)
+
+  Run with:
+      mix test.sanity test/sanity/consumer_group_sanity_test.exs
+  """
+  use Kayrock.SanityCase
+  use ExUnit.Case, async: false
+
+  import Kayrock.RequestFactory
+
+  container(:kafka, KafkaContainer.new(), shared: true)
+
+  # ---------------------------------------------------------------------------
+  # setup_all: shared client and topic
+  # ---------------------------------------------------------------------------
+
+  setup_all %{kafka: kafka} do
+    {:ok, client} = build_client(kafka)
+    topic = create_topic(client, 5)
+    :ok = wait_for_topic(client, topic)
+    %{client: client, topic: topic}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Group lifecycle helpers
+  # ---------------------------------------------------------------------------
+
+  # Join a fresh group (as leader/sole member), return context map.
+  # Uses JoinGroup V2 which is widely-supported and has rebalance_timeout_ms.
+  defp join_fresh_group(client, topic) do
+    group_id = "sanity-cg-#{unique_string()}"
+    vsn = min(2, Kayrock.FindCoordinator.max_vsn())
+    coord_req = find_coordinator_request(group_id, vsn)
+
+    {:ok, coord_resp} =
+      with_retry(fn -> Kayrock.client_call(client, coord_req, :random) end)
+
+    node_id = coord_resp.node_id
+
+    join_req =
+      join_group_request(%{group_id: group_id, topics: [topic]}, 2)
+
+    {:ok, join_resp} =
+      with_retry(fn -> Kayrock.client_call(client, join_req, node_id) end)
+
+    assert join_resp.error_code == 0,
+           "JoinGroup failed in join_fresh_group: #{join_resp.error_code}"
+
+    %{
+      group_id: group_id,
+      node_id: node_id,
+      member_id: join_resp.member_id,
+      generation_id: join_resp.generation_id
+    }
+  end
+
+  # Join AND sync a group so it reaches the Stable state.
+  # Returns the same context map.
+  defp join_and_sync_group(client, topic) do
+    ctx = join_fresh_group(client, topic)
+    %{group_id: group_id, node_id: node_id, member_id: member_id, generation_id: gen_id} = ctx
+
+    assignments = [%{member_id: member_id, topic: topic, partitions: [0, 1, 2]}]
+
+    sync_req =
+      group_id
+      |> sync_group_request(member_id, assignments, 2)
+      |> Map.put(:generation_id, gen_id)
+
+    {:ok, sync_resp} =
+      with_retry(fn -> Kayrock.client_call(client, sync_req, node_id) end)
+
+    assert sync_resp.error_code == 0,
+           "SyncGroup failed in join_and_sync_group: #{sync_resp.error_code}"
+
+    ctx
+  end
+
+  # Leave a group cleanly (V0 protocol).
+  defp leave_group(client, group_id, member_id, node_id) do
+    leave_req = leave_group_request(group_id, member_id, 0)
+
+    with_retry(
+      fn -> Kayrock.client_call(client, leave_req, node_id) end,
+      accept_errors: [0]
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # FindCoordinator V0-V3
+  # ---------------------------------------------------------------------------
+
+  describe "FindCoordinator" do
+    for version <- 0..3 do
+      @tag api: :find_coordinator, version: version
+      test "V#{version} returns coordinator for a group", %{client: client} do
+        version = unquote(version)
+        group_id = "sanity-fc-#{unique_string()}"
+
+        request = find_coordinator_request(group_id, version)
+
+        {:ok, response} =
+          with_retry(fn -> Kayrock.client_call(client, request, :random) end)
+
+        assert response.error_code == 0,
+               "V#{version} expected error_code 0, got #{response.error_code}"
+
+        assert is_integer(response.node_id),
+               "V#{version} node_id should be integer"
+
+        assert is_binary(response.host),
+               "V#{version} host should be binary"
+
+        assert is_integer(response.port),
+               "V#{version} port should be integer > 0"
+
+        assert response.port > 0
+      end
+    end
+
+    # V0 has no throttle_time_ms or error_message
+    @tag api: :find_coordinator, version: 0
+    test "V0 response has no throttle_time_ms or error_message", %{client: client} do
+      group_id = "sanity-fc-#{unique_string()}"
+      request = find_coordinator_request(group_id, 0)
+      {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, :random) end)
+
+      refute Map.has_key?(response, :throttle_time_ms),
+             "V0 response should not have throttle_time_ms"
+
+      refute Map.has_key?(response, :error_message),
+             "V0 response should not have error_message"
+    end
+
+    # V1+ include throttle_time_ms and error_message
+    for version <- 1..3 do
+      @tag api: :find_coordinator, version: version
+      test "V#{version} response includes throttle_time_ms and error_message", %{client: client} do
+        version = unquote(version)
+        group_id = "sanity-fc-#{unique_string()}"
+        request = find_coordinator_request(group_id, version)
+        {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, :random) end)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        # error_message is nullable; on success it's nil
+        assert is_nil(response.error_message) or is_binary(response.error_message),
+               "V#{version} error_message should be nil or binary"
+      end
+    end
+
+    # V3 is flexible — response includes tagged_fields
+    @tag api: :find_coordinator, version: 3
+    test "V3 response includes tagged_fields (flexible version)", %{client: client} do
+      group_id = "sanity-fc-#{unique_string()}"
+      request = find_coordinator_request(group_id, 3)
+      {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, :random) end)
+
+      assert is_list(response.tagged_fields),
+             "V3 response.tagged_fields should be a list (flexible)"
+    end
+
+    # V0 request struct must NOT have key_type field
+    @tag api: :find_coordinator, version: 0
+    test "V0 request struct has no key_type field", %{client: client} do
+      group_id = "sanity-fc-#{unique_string()}"
+      request = find_coordinator_request(group_id, 0)
+
+      refute Map.has_key?(request, :key_type),
+             "V0 request should not have key_type"
+
+      # Should still succeed
+      {:ok, _response} = with_retry(fn -> Kayrock.client_call(client, request, :random) end)
+    end
+
+    # V1+ request struct MUST have key_type field
+    for version <- 1..3 do
+      @tag api: :find_coordinator, version: version
+      test "V#{version} request struct has key_type field", %{client: client} do
+        version = unquote(version)
+        group_id = "sanity-fc-#{unique_string()}"
+        request = find_coordinator_request(group_id, version)
+
+        assert Map.has_key?(request, :key_type),
+               "V#{version} request should have key_type"
+
+        assert request.key_type == 0,
+               "V#{version} key_type should be 0 for consumer group"
+
+        {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, :random) end)
+        assert response.error_code == 0
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # JoinGroup V0-V6
+  # ---------------------------------------------------------------------------
+
+  describe "JoinGroup" do
+    for version <- 0..6 do
+      @tag api: :join_group, version: version
+      test "V#{version} can join a new group", %{client: client, topic: topic} do
+        version = unquote(version)
+        group_id = "sanity-jg-v#{version}-#{unique_string()}"
+
+        # Find coordinator first
+        coord_req = find_coordinator_request(group_id, min(2, Kayrock.FindCoordinator.max_vsn()))
+        {:ok, coord_resp} = with_retry(fn -> Kayrock.client_call(client, coord_req, :random) end)
+        node_id = coord_resp.node_id
+
+        # V4+ requires KIP-394 two-step join: broker may return error 79
+        # (MEMBER_ID_REQUIRED) with an assigned member_id, which must be used
+        # in the second join request.
+        {:ok, response} =
+          if version >= 4 do
+            join_group_kip394(client, group_id, topic, node_id, version)
+          else
+            request = build_join_group_request(group_id, topic, version)
+            with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+          end
+
+        assert response.error_code == 0,
+               "V#{version} JoinGroup error_code should be 0, got #{response.error_code}"
+
+        assert is_binary(response.member_id) and response.member_id != "",
+               "V#{version} member_id should be non-empty string"
+
+        assert is_integer(response.generation_id),
+               "V#{version} generation_id should be integer"
+
+        assert response.generation_id >= 1,
+               "V#{version} generation_id should be >= 1"
+
+        assert is_list(response.members),
+               "V#{version} members should be a list"
+
+        assert is_binary(response.leader),
+               "V#{version} leader should be binary"
+
+        assert is_binary(response.protocol_name),
+               "V#{version} protocol_name should be binary"
+      end
+    end
+
+    # V6 is flexible — response has tagged_fields
+    @tag api: :join_group, version: 6
+    test "V6 response has tagged_fields (flexible)", %{client: client, topic: topic} do
+      group_id = "sanity-jg-flex-#{unique_string()}"
+      coord_req = find_coordinator_request(group_id, min(2, Kayrock.FindCoordinator.max_vsn()))
+      {:ok, coord_resp} = with_retry(fn -> Kayrock.client_call(client, coord_req, :random) end)
+      node_id = coord_resp.node_id
+
+      {:ok, response} = join_group_kip394(client, group_id, topic, node_id, 6)
+      assert response.error_code == 0
+
+      assert is_list(response.tagged_fields),
+             "V6 response.tagged_fields should be a list"
+    end
+
+    # V0 has no rebalance_timeout_ms in request
+    @tag api: :join_group, version: 0
+    test "V0 request struct has no rebalance_timeout_ms", %{client: client, topic: topic} do
+      group_id = "sanity-jg-v0rt-#{unique_string()}"
+      request = build_join_group_request(group_id, topic, 0)
+
+      refute Map.has_key?(request, :rebalance_timeout_ms),
+             "V0 request should not have rebalance_timeout_ms"
+
+      coord_req = find_coordinator_request(group_id, 0)
+      {:ok, coord_resp} = with_retry(fn -> Kayrock.client_call(client, coord_req, :random) end)
+
+      {:ok, response} =
+        with_retry(fn -> Kayrock.client_call(client, request, coord_resp.node_id) end)
+
+      assert response.error_code == 0
+    end
+
+    # V1+ has rebalance_timeout_ms in request
+    @tag api: :join_group, version: 1
+    test "V1+ request struct has rebalance_timeout_ms", %{topic: topic} do
+      request = build_join_group_request("test-rebalance-#{unique_string()}", topic, 1)
+
+      assert Map.has_key?(request, :rebalance_timeout_ms),
+             "V1+ request should have rebalance_timeout_ms"
+    end
+
+    # V5+ has group_instance_id in request
+    for version <- 5..6 do
+      @tag api: :join_group, version: version
+      test "V#{version} request struct has group_instance_id", %{topic: topic} do
+        version = unquote(version)
+        request = build_join_group_request("test-gi-#{unique_string()}", topic, version)
+
+        assert Map.has_key?(request, :group_instance_id),
+               "V#{version} request should have group_instance_id"
+      end
+    end
+
+    # Sole member becomes the leader
+    @tag api: :join_group
+    test "sole member is the leader", %{client: client, topic: topic} do
+      group_id = "sanity-jg-leader-#{unique_string()}"
+      coord_req = find_coordinator_request(group_id, 2)
+      {:ok, coord_resp} = with_retry(fn -> Kayrock.client_call(client, coord_req, :random) end)
+      node_id = coord_resp.node_id
+
+      request = build_join_group_request(group_id, topic, 2)
+      {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+      assert response.error_code == 0
+
+      assert response.leader == response.member_id,
+             "sole member should be the leader"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # SyncGroup V0-V4
+  # ---------------------------------------------------------------------------
+
+  describe "SyncGroup" do
+    for version <- 0..4 do
+      @tag api: :sync_group, version: version
+      test "V#{version} sync a group returns assignment", %{client: client, topic: topic} do
+        version = unquote(version)
+        ctx = join_fresh_group(client, topic)
+
+        %{group_id: group_id, node_id: node_id, member_id: member_id, generation_id: gen_id} =
+          ctx
+
+        assignments = [%{member_id: member_id, topic: topic, partitions: [0, 1, 2]}]
+        request = build_sync_group_request(group_id, member_id, assignments, gen_id, version)
+
+        {:ok, response} =
+          with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+
+        assert response.error_code == 0,
+               "V#{version} SyncGroup error_code should be 0, got #{response.error_code}"
+
+        # SyncGroup response deserializes the assignment bytes into a MemberAssignment struct
+        assert is_struct(response.assignment, Kayrock.MemberAssignment) or
+                 is_nil(response.assignment),
+               "V#{version} assignment should be a MemberAssignment struct (got #{inspect(response.assignment)})"
+      end
+    end
+
+    # V3+ has group_instance_id in request
+    for version <- 3..4 do
+      @tag api: :sync_group, version: version
+      test "V#{version} request struct has group_instance_id", %{topic: topic} do
+        version = unquote(version)
+        request = Kayrock.SyncGroup.get_request_struct(version)
+
+        assert Map.has_key?(request, :group_instance_id),
+               "V#{version} SyncGroup request should have group_instance_id"
+      end
+    end
+
+    # V4 has tagged_fields in request
+    @tag api: :sync_group, version: 4
+    test "V4 request has tagged_fields (flexible)", %{client: client, topic: topic} do
+      ctx = join_fresh_group(client, topic)
+      %{group_id: group_id, node_id: node_id, member_id: member_id, generation_id: gen_id} = ctx
+
+      assignments = [%{member_id: member_id, topic: topic, partitions: [0, 1, 2]}]
+      request = build_sync_group_request(group_id, member_id, assignments, gen_id, 4)
+
+      assert Map.has_key?(request, :tagged_fields),
+             "V4 SyncGroup request should have tagged_fields"
+
+      {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+      assert response.error_code == 0
+    end
+
+    # V0 has no group_instance_id
+    @tag api: :sync_group, version: 0
+    test "V0 request struct has no group_instance_id" do
+      request = Kayrock.SyncGroup.get_request_struct(0)
+
+      refute Map.has_key?(request, :group_instance_id),
+             "V0 SyncGroup request should not have group_instance_id"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Heartbeat V0-V4
+  # ---------------------------------------------------------------------------
+
+  describe "Heartbeat" do
+    for version <- 0..4 do
+      @tag api: :heartbeat, version: version
+      test "V#{version} heartbeat to active group succeeds", %{client: client, topic: topic} do
+        version = unquote(version)
+        ctx = join_and_sync_group(client, topic)
+
+        %{group_id: group_id, node_id: node_id, member_id: member_id, generation_id: gen_id} =
+          ctx
+
+        request = build_heartbeat_request(group_id, member_id, gen_id, version)
+
+        {:ok, response} =
+          with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+
+        assert response.error_code == 0,
+               "V#{version} Heartbeat error_code should be 0, got #{response.error_code}"
+      end
+    end
+
+    # V0-V2 have no group_instance_id; V3+ does have it
+    for version <- 0..2 do
+      @tag api: :heartbeat, version: version
+      test "V#{version} request struct has no group_instance_id" do
+        version = unquote(version)
+        request = Kayrock.Heartbeat.get_request_struct(version)
+
+        refute Map.has_key?(request, :group_instance_id),
+               "V#{version} Heartbeat request should not have group_instance_id"
+      end
+    end
+
+    # V3 has group_instance_id (but no tagged_fields yet)
+    @tag api: :heartbeat, version: 3
+    test "V3 request struct has group_instance_id" do
+      request = Kayrock.Heartbeat.get_request_struct(3)
+
+      assert Map.has_key?(request, :group_instance_id),
+             "V3 Heartbeat request should have group_instance_id"
+
+      refute Map.has_key?(request, :tagged_fields),
+             "V3 Heartbeat request should not have tagged_fields"
+    end
+
+    # V4 has group_instance_id and tagged_fields
+    @tag api: :heartbeat, version: 4
+    test "V4 request struct has group_instance_id and tagged_fields" do
+      request = Kayrock.Heartbeat.get_request_struct(4)
+
+      assert Map.has_key?(request, :group_instance_id),
+             "V4 Heartbeat request should have group_instance_id"
+
+      assert Map.has_key?(request, :tagged_fields),
+             "V4 Heartbeat request should have tagged_fields"
+    end
+
+    # Heartbeat with wrong generation_id should return ILLEGAL_GENERATION (22)
+    @tag api: :heartbeat
+    test "heartbeat with wrong generation_id returns error", %{client: client, topic: topic} do
+      ctx = join_and_sync_group(client, topic)
+      %{group_id: group_id, node_id: node_id, member_id: member_id} = ctx
+
+      # Use a clearly wrong generation id
+      request = heartbeat_request(group_id, member_id, 9_999_999, 2)
+      {:ok, response} = Kayrock.client_call(client, request, node_id)
+
+      # ILLEGAL_GENERATION(22) or UNKNOWN_MEMBER_ID(25) or REBALANCE_IN_PROGRESS(27)
+      assert response.error_code in [22, 25, 27],
+             "Expected error for bad generation_id, got #{response.error_code}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # LeaveGroup V0-V4
+  # ---------------------------------------------------------------------------
+
+  describe "LeaveGroup" do
+    # V0-V2: single member_id field
+    for version <- 0..2 do
+      @tag api: :leave_group, version: version
+      test "V#{version} leave group with single member_id", %{client: client, topic: topic} do
+        version = unquote(version)
+        ctx = join_and_sync_group(client, topic)
+        %{group_id: group_id, node_id: node_id, member_id: member_id} = ctx
+
+        request = build_leave_group_request(group_id, member_id, version)
+
+        {:ok, response} =
+          with_retry(
+            fn -> Kayrock.client_call(client, request, node_id) end,
+            accept_errors: [0]
+          )
+
+        assert response.error_code == 0,
+               "V#{version} LeaveGroup error_code should be 0, got #{response.error_code}"
+      end
+    end
+
+    # V0-V2 struct has member_id field
+    for version <- 0..2 do
+      @tag api: :leave_group, version: version
+      test "V#{version} request struct has member_id field" do
+        version = unquote(version)
+        request = Kayrock.LeaveGroup.get_request_struct(version)
+
+        assert Map.has_key?(request, :member_id),
+               "V#{version} LeaveGroup request should have member_id"
+
+        refute Map.has_key?(request, :members),
+               "V#{version} LeaveGroup request should NOT have members list"
+      end
+    end
+
+    # V3-V4: uses members list, NOT member_id
+    for version <- 3..4 do
+      @tag api: :leave_group, version: version
+      test "V#{version} leave group with members list", %{client: client, topic: topic} do
+        version = unquote(version)
+        ctx = join_and_sync_group(client, topic)
+        %{group_id: group_id, node_id: node_id, member_id: member_id} = ctx
+
+        request = build_leave_group_v3_plus_request(group_id, member_id, version)
+
+        {:ok, response} =
+          with_retry(
+            fn -> Kayrock.client_call(client, request, node_id) end,
+            accept_errors: [0]
+          )
+
+        assert response.error_code == 0,
+               "V#{version} LeaveGroup (members list) error_code should be 0, got #{response.error_code}"
+      end
+    end
+
+    # V3-V4 struct has members list field, NOT member_id
+    for version <- 3..4 do
+      @tag api: :leave_group, version: version
+      test "V#{version} request struct has members list, no member_id" do
+        version = unquote(version)
+        request = Kayrock.LeaveGroup.get_request_struct(version)
+
+        assert Map.has_key?(request, :members),
+               "V#{version} LeaveGroup request should have members list"
+
+        refute Map.has_key?(request, :member_id),
+               "V#{version} LeaveGroup request should NOT have member_id (batch leave)"
+      end
+    end
+
+    # V4 has tagged_fields
+    @tag api: :leave_group, version: 4
+    test "V4 request struct has tagged_fields (flexible)" do
+      request = Kayrock.LeaveGroup.get_request_struct(4)
+
+      assert Map.has_key?(request, :tagged_fields),
+             "V4 LeaveGroup request should have tagged_fields"
+    end
+
+    # V3+ response has members list
+    for version <- 3..4 do
+      @tag api: :leave_group, version: version
+      test "V#{version} response includes members list", %{client: client, topic: topic} do
+        version = unquote(version)
+        ctx = join_and_sync_group(client, topic)
+        %{group_id: group_id, node_id: node_id, member_id: member_id} = ctx
+
+        request = build_leave_group_v3_plus_request(group_id, member_id, version)
+
+        {:ok, response} =
+          with_retry(
+            fn -> Kayrock.client_call(client, request, node_id) end,
+            accept_errors: [0]
+          )
+
+        assert response.error_code == 0
+
+        assert is_list(response.members),
+               "V#{version} LeaveGroup response should have members list"
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # DescribeGroups V0-V5
+  # ---------------------------------------------------------------------------
+
+  describe "DescribeGroups" do
+    for version <- 0..5 do
+      @tag api: :describe_groups, version: version
+      test "V#{version} describe an existing group", %{client: client, topic: topic} do
+        version = unquote(version)
+        ctx = join_and_sync_group(client, topic)
+        %{group_id: group_id, node_id: node_id} = ctx
+
+        request = build_describe_groups_request([group_id], version)
+
+        {:ok, response} =
+          with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+
+        assert is_list(response.groups),
+               "V#{version} response.groups should be a list"
+
+        assert length(response.groups) == 1,
+               "V#{version} expected 1 group in response"
+
+        [group] = response.groups
+
+        assert group.error_code == 0,
+               "V#{version} group.error_code should be 0, got #{group.error_code}"
+
+        assert group.group_id == group_id,
+               "V#{version} group.group_id should match"
+      end
+    end
+
+    # V1+ has throttle_time_ms
+    for version <- 1..5 do
+      @tag api: :describe_groups, version: version
+      test "V#{version} response includes throttle_time_ms", %{client: client, topic: topic} do
+        version = unquote(version)
+        ctx = join_and_sync_group(client, topic)
+        %{group_id: group_id, node_id: node_id} = ctx
+
+        request = build_describe_groups_request([group_id], version)
+        {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+      end
+    end
+
+    # V5 is flexible — request has include_authorized_operations + tagged_fields
+    @tag api: :describe_groups, version: 5
+    test "V5 request struct has include_authorized_operations and tagged_fields" do
+      request = Kayrock.DescribeGroups.get_request_struct(5)
+
+      assert Map.has_key?(request, :include_authorized_operations),
+             "V5 request should have include_authorized_operations"
+
+      assert Map.has_key?(request, :tagged_fields),
+             "V5 request should have tagged_fields"
+    end
+
+    # V5 response also has tagged_fields
+    @tag api: :describe_groups, version: 5
+    test "V5 response includes tagged_fields (flexible)", %{client: client, topic: topic} do
+      ctx = join_and_sync_group(client, topic)
+      %{group_id: group_id, node_id: node_id} = ctx
+
+      request = build_describe_groups_request([group_id], 5)
+      {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+
+      # Groups are in compact format; response struct may have tagged_fields
+      assert is_list(response.groups)
+    end
+
+    # Describe non-existent group returns UNKNOWN_MEMBER_ID or INVALID_GROUP_ID or 0
+    @tag api: :describe_groups
+    test "describing non-existent group returns sensible response", %{client: client} do
+      request = describe_groups_request(["no-such-group-#{unique_string()}"], 2)
+      {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, :random) end)
+
+      assert is_list(response.groups)
+      [group] = response.groups
+      # Typically returns error_code 0 with state "Dead" for unknown group
+      assert is_integer(group.error_code)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # OffsetCommit V0-V8
+  # ---------------------------------------------------------------------------
+
+  describe "OffsetCommit" do
+    for version <- 0..8 do
+      @tag api: :offset_commit, version: version
+      test "V#{version} commit offset succeeds", %{client: client, topic: topic} do
+        version = unquote(version)
+        ctx = join_and_sync_group(client, topic)
+
+        %{group_id: group_id, node_id: node_id, member_id: member_id, generation_id: gen_id} =
+          ctx
+
+        request = build_offset_commit_request(group_id, topic, member_id, gen_id, version)
+
+        {:ok, response} =
+          with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+
+        assert is_list(response.topics),
+               "V#{version} response.topics should be a list"
+
+        assert response.topics != [],
+               "V#{version} response.topics should not be empty"
+
+        [topic_resp] = response.topics
+
+        assert is_list(topic_resp.partitions),
+               "V#{version} topic partitions should be a list"
+
+        [partition_resp] = topic_resp.partitions
+
+        assert partition_resp.error_code == 0,
+               "V#{version} partition error_code should be 0, got #{partition_resp.error_code}"
+      end
+    end
+
+    # V0 has no generation_id or member_id
+    @tag api: :offset_commit, version: 0
+    test "V0 request struct has no generation_id or member_id" do
+      request = Kayrock.OffsetCommit.get_request_struct(0)
+
+      refute Map.has_key?(request, :generation_id),
+             "V0 OffsetCommit request should not have generation_id"
+
+      refute Map.has_key?(request, :member_id),
+             "V0 OffsetCommit request should not have member_id"
+    end
+
+    # V1+ has generation_id and member_id
+    for version <- 1..8 do
+      @tag api: :offset_commit, version: version
+      test "V#{version} request struct has generation_id and member_id" do
+        version = unquote(version)
+        request = Kayrock.OffsetCommit.get_request_struct(version)
+
+        assert Map.has_key?(request, :generation_id),
+               "V#{version} OffsetCommit request should have generation_id"
+
+        assert Map.has_key?(request, :member_id),
+               "V#{version} OffsetCommit request should have member_id"
+      end
+    end
+
+    # V8 has group_instance_id and tagged_fields
+    @tag api: :offset_commit, version: 8
+    test "V8 request struct has group_instance_id and tagged_fields" do
+      request = Kayrock.OffsetCommit.get_request_struct(8)
+
+      assert Map.has_key?(request, :group_instance_id),
+             "V8 OffsetCommit request should have group_instance_id"
+
+      assert Map.has_key?(request, :tagged_fields),
+             "V8 OffsetCommit request should have tagged_fields"
+    end
+
+    # V1 has commit_timestamp in partition data (need special handling)
+    @tag api: :offset_commit, version: 1
+    test "V1 commit with explicit timestamp succeeds", %{client: client, topic: topic} do
+      ctx = join_and_sync_group(client, topic)
+      %{group_id: group_id, node_id: node_id, member_id: member_id, generation_id: gen_id} = ctx
+
+      request = build_offset_commit_request(group_id, topic, member_id, gen_id, 1)
+      {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+
+      assert is_list(response.topics)
+      [topic_resp] = response.topics
+      [partition_resp] = topic_resp.partitions
+      assert partition_resp.error_code == 0
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # OffsetFetch V0-V6
+  # ---------------------------------------------------------------------------
+
+  describe "OffsetFetch" do
+    for version <- 0..6 do
+      @tag api: :offset_fetch, version: version
+      test "V#{version} fetch committed offsets", %{client: client, topic: topic} do
+        version = unquote(version)
+        ctx = join_and_sync_group(client, topic)
+
+        %{group_id: group_id, node_id: node_id, member_id: member_id, generation_id: gen_id} =
+          ctx
+
+        # Commit offsets first using a compatible version
+        commit_vsn = min(version, 8)
+        commit_req = build_offset_commit_request(group_id, topic, member_id, gen_id, commit_vsn)
+
+        {:ok, _commit_resp} =
+          with_retry(fn -> Kayrock.client_call(client, commit_req, node_id) end)
+
+        # Now fetch
+        request = build_offset_fetch_request(group_id, topic, version)
+
+        {:ok, response} =
+          with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+
+        assert is_list(response.topics),
+               "V#{version} response.topics should be a list"
+      end
+    end
+
+    # V3+ has throttle_time_ms (V0-V2 do not have it; V2 only has error_code at top level)
+    for version <- 3..6 do
+      @tag api: :offset_fetch, version: version
+      test "V#{version} response includes throttle_time_ms", %{client: client, topic: topic} do
+        version = unquote(version)
+        ctx = join_and_sync_group(client, topic)
+        %{group_id: group_id, node_id: node_id} = ctx
+
+        request = build_offset_fetch_request(group_id, topic, version)
+        {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} response.throttle_time_ms should be integer"
+      end
+    end
+
+    # V6 is flexible — tagged_fields in request and response
+    @tag api: :offset_fetch, version: 6
+    test "V6 request struct has tagged_fields",
+      do:
+        (
+          request = Kayrock.OffsetFetch.get_request_struct(6)
+
+          assert Map.has_key?(request, :tagged_fields),
+                 "V6 OffsetFetch request should have tagged_fields"
+        )
+
+    # V6 response also has error_code at top level (introduced in V2)
+    for version <- 2..6 do
+      @tag api: :offset_fetch, version: version
+      test "V#{version} response includes error_code at top level", %{
+        client: client,
+        topic: topic
+      } do
+        version = unquote(version)
+        ctx = join_and_sync_group(client, topic)
+        %{group_id: group_id, node_id: node_id} = ctx
+
+        request = build_offset_fetch_request(group_id, topic, version)
+        {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+
+        assert is_integer(response.error_code),
+               "V#{version} response should have error_code"
+
+        assert response.error_code == 0,
+               "V#{version} response error_code should be 0"
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # DeleteGroups V0-V2
+  # ---------------------------------------------------------------------------
+
+  describe "DeleteGroups" do
+    for version <- 0..2 do
+      @tag api: :delete_groups, version: version
+      test "V#{version} delete an empty (left) group", %{client: client, topic: topic} do
+        version = unquote(version)
+        ctx = join_and_sync_group(client, topic)
+        %{group_id: group_id, node_id: node_id, member_id: member_id} = ctx
+
+        # Leave the group first so it becomes Empty
+        leave_group(client, group_id, member_id, node_id)
+        # Wait for the group to reach Empty/Dead state before deleting
+        :timer.sleep(1000)
+
+        request = build_delete_groups_request([group_id], version)
+
+        # DeleteGroups response has no top-level error_code, so with_retry would
+        # loop endlessly treating it as "other". Call directly and retry on nested error.
+        {:ok, response} = delete_group_with_retry(client, request, node_id)
+
+        assert is_list(response.results),
+               "V#{version} response.results should be a list"
+
+        [result] = response.results
+
+        assert result.group_id == group_id,
+               "V#{version} result.group_id should match"
+
+        # 0 = deleted successfully; 69 = GROUP_ID_NOT_FOUND (broker already
+        # garbage-collected the Dead group before our request arrived — effectively deleted)
+        assert result.error_code in [0, 69],
+               "V#{version} result.error_code should be 0 or 69, got #{result.error_code}"
+      end
+    end
+
+    # V0-V1 have no tagged_fields
+    for version <- 0..1 do
+      @tag api: :delete_groups, version: version
+      test "V#{version} request struct has no tagged_fields" do
+        version = unquote(version)
+        request = Kayrock.DeleteGroups.get_request_struct(version)
+
+        refute Map.has_key?(request, :tagged_fields),
+               "V#{version} DeleteGroups request should not have tagged_fields"
+      end
+    end
+
+    # V2 has tagged_fields
+    @tag api: :delete_groups, version: 2
+    test "V2 request struct has tagged_fields (flexible)" do
+      request = Kayrock.DeleteGroups.get_request_struct(2)
+
+      assert Map.has_key?(request, :tagged_fields),
+             "V2 DeleteGroups request should have tagged_fields"
+    end
+
+    # groups_names field
+    @tag api: :delete_groups
+    test "request struct has groups_names field" do
+      request = Kayrock.DeleteGroups.get_request_struct(0)
+
+      assert Map.has_key?(request, :groups_names),
+             "DeleteGroups request should have groups_names field"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # OffsetDelete V0
+  # ---------------------------------------------------------------------------
+
+  describe "OffsetDelete" do
+    @tag api: :offset_delete, version: 0
+    test "V0 delete committed offsets for a group", %{client: client, topic: topic} do
+      ctx = join_and_sync_group(client, topic)
+      %{group_id: group_id, node_id: node_id, member_id: member_id, generation_id: gen_id} = ctx
+
+      # Commit an offset first
+      commit_req = build_offset_commit_request(group_id, topic, member_id, gen_id, 2)
+      {:ok, _} = with_retry(fn -> Kayrock.client_call(client, commit_req, node_id) end)
+
+      # Leave the group so we can delete offsets (group must be Empty)
+      leave_group(client, group_id, member_id, node_id)
+      :timer.sleep(500)
+
+      request = build_offset_delete_request(group_id, topic)
+
+      {:ok, response} =
+        with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+
+      assert is_integer(response.error_code),
+             "V0 OffsetDelete response should have error_code"
+
+      assert response.error_code == 0,
+             "V0 OffsetDelete error_code should be 0, got #{response.error_code}"
+
+      assert is_integer(response.throttle_time_ms),
+             "V0 OffsetDelete response should have throttle_time_ms"
+
+      assert is_list(response.topics),
+             "V0 OffsetDelete response should have topics list"
+    end
+
+    @tag api: :offset_delete, version: 0
+    test "V0 response has correct field layout" do
+      request = Kayrock.OffsetDelete.get_request_struct(0)
+
+      assert Map.has_key?(request, :group_id),
+             "V0 OffsetDelete request should have group_id"
+
+      assert Map.has_key?(request, :topics),
+             "V0 OffsetDelete request should have topics"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private request builders
+  # ---------------------------------------------------------------------------
+
+  # JoinGroup request builder — handles V0 (no rebalance_timeout) vs V1-V4 vs V5+ (group_instance_id)
+  defp build_join_group_request(group_id, topic, version, member_id \\ "") do
+    vsn = min(version, Kayrock.JoinGroup.max_vsn())
+    request = Kayrock.JoinGroup.get_request_struct(vsn)
+    metadata = %Kayrock.GroupProtocolMetadata{topics: [topic]}
+
+    base = %{
+      request
+      | group_id: group_id,
+        session_timeout_ms: 10_000,
+        member_id: member_id,
+        protocol_type: "consumer",
+        protocols: [%{name: "assign", metadata: metadata}]
+    }
+
+    base =
+      if vsn >= 1 do
+        %{base | rebalance_timeout_ms: 30_000}
+      else
+        base
+      end
+
+    base =
+      if vsn >= 5 do
+        %{base | group_instance_id: nil}
+      else
+        base
+      end
+
+    if vsn >= 6 do
+      %{base | tagged_fields: []}
+    else
+      base
+    end
+  end
+
+  # KIP-394 two-step join helper for JoinGroup V4+.
+  # The broker may respond with error 79 (MEMBER_ID_REQUIRED) and a new member_id.
+  # We must retry with that member_id. Standard with_retry retries the original
+  # closure (with member_id: "") so we handle this manually.
+  defp join_group_kip394(client, group_id, topic, node_id, version, retries \\ 10) do
+    join_group_kip394_loop(client, group_id, topic, node_id, version, "", retries)
+  end
+
+  defp join_group_kip394_loop(_client, _group_id, _topic, _node_id, _version, _member_id, 0) do
+    {:error, :max_retries_exceeded}
+  end
+
+  defp join_group_kip394_loop(client, group_id, topic, node_id, version, member_id, retries) do
+    request = build_join_group_request(group_id, topic, version, member_id)
+
+    case Kayrock.client_call(client, request, node_id) do
+      {:ok, %{error_code: 0} = response} ->
+        {:ok, response}
+
+      {:ok, %{error_code: 79, member_id: new_member_id}}
+      when is_binary(new_member_id) and new_member_id != "" ->
+        # MEMBER_ID_REQUIRED — broker assigned us a member_id; retry with it
+        :timer.sleep(500)
+
+        join_group_kip394_loop(
+          client,
+          group_id,
+          topic,
+          node_id,
+          version,
+          new_member_id,
+          retries - 1
+        )
+
+      {:ok, %{error_code: code}} when code in [15, 16, 25, 27] ->
+        # Transient coordinator errors — retry with same member_id
+        :timer.sleep(500)
+        join_group_kip394_loop(client, group_id, topic, node_id, version, member_id, retries - 1)
+
+      {:ok, response} ->
+        {:ok, response}
+
+      {:error, _} ->
+        :timer.sleep(500)
+        join_group_kip394_loop(client, group_id, topic, node_id, version, member_id, retries - 1)
+    end
+  end
+
+  # DeleteGroups response has no top-level error_code, so with_retry cannot
+  # detect success vs transient failure. Retry on nested result error_code.
+  defp delete_group_with_retry(client, request, node_id, retries \\ 10)
+
+  defp delete_group_with_retry(_client, _request, _node_id, 0),
+    do: {:error, :max_retries_exceeded}
+
+  defp delete_group_with_retry(client, request, node_id, retries) do
+    case Kayrock.client_call(client, request, node_id) do
+      {:ok, %{results: [%{error_code: 0}]} = response} ->
+        {:ok, response}
+
+      {:ok, %{results: [%{error_code: code}]}} when code in [15, 16, 68] ->
+        # 15=COORDINATOR_NOT_AVAILABLE, 16=NOT_COORDINATOR,
+        # 68=NON_EMPTY_GROUP (group not yet transitioned to Empty — retry)
+        :timer.sleep(700)
+        delete_group_with_retry(client, request, node_id, retries - 1)
+
+      {:ok, response} ->
+        {:ok, response}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  # SyncGroup request builder — handles all versions
+  defp build_sync_group_request(group_id, member_id, assignments, generation_id, version) do
+    vsn = min(version, Kayrock.SyncGroup.max_vsn())
+
+    request =
+      group_id
+      |> sync_group_request(member_id, assignments, vsn)
+      |> Map.put(:generation_id, generation_id)
+
+    request =
+      if vsn >= 3 do
+        %{request | group_instance_id: nil}
+      else
+        request
+      end
+
+    if vsn >= 4 do
+      %{request | tagged_fields: []}
+    else
+      request
+    end
+  end
+
+  # Heartbeat request builder — handles all versions
+  defp build_heartbeat_request(group_id, member_id, generation_id, version) do
+    vsn = min(version, Kayrock.Heartbeat.max_vsn())
+    request = heartbeat_request(group_id, member_id, generation_id, vsn)
+
+    request =
+      if vsn >= 4 do
+        %{request | group_instance_id: nil, tagged_fields: []}
+      else
+        request
+      end
+
+    request
+  end
+
+  # LeaveGroup V0-V2 request builder (member_id based)
+  defp build_leave_group_request(group_id, member_id, version) do
+    vsn = min(version, 2)
+    leave_group_request(group_id, member_id, vsn)
+  end
+
+  # LeaveGroup V3-V4 request builder (members list based)
+  defp build_leave_group_v3_plus_request(group_id, member_id, version) do
+    vsn = min(version, Kayrock.LeaveGroup.max_vsn())
+    vsn = max(vsn, 3)
+    request = Kayrock.LeaveGroup.get_request_struct(vsn)
+
+    member =
+      if vsn >= 4 do
+        %{member_id: member_id, group_instance_id: nil, tagged_fields: []}
+      else
+        %{member_id: member_id, group_instance_id: nil}
+      end
+
+    base = %{request | group_id: group_id, members: [member]}
+
+    if vsn >= 4 do
+      %{base | tagged_fields: []}
+    else
+      base
+    end
+  end
+
+  # DescribeGroups request builder — handles all versions
+  defp build_describe_groups_request(group_ids, version) do
+    vsn = min(version, Kayrock.DescribeGroups.max_vsn())
+    request = describe_groups_request(group_ids, vsn)
+
+    if vsn >= 5 do
+      %{request | include_authorized_operations: false, tagged_fields: []}
+    else
+      request
+    end
+  end
+
+  # OffsetCommit request builder — handles all versions
+  defp build_offset_commit_request(group_id, topic, member_id, generation_id, version) do
+    vsn = min(version, Kayrock.OffsetCommit.max_vsn())
+
+    topics_data = [
+      [
+        topic: topic,
+        partitions: [[partition: 0, offset: 1]]
+      ]
+    ]
+
+    opts = [generation_id: generation_id, member_id: member_id]
+
+    request = offset_commit_request(group_id, topics_data, vsn, opts)
+
+    if vsn >= 8 do
+      %{request | group_instance_id: nil, tagged_fields: []}
+    else
+      request
+    end
+  end
+
+  # OffsetFetch request builder — handles all versions
+  defp build_offset_fetch_request(group_id, topic, version) do
+    vsn = min(version, Kayrock.OffsetFetch.max_vsn())
+
+    topics_data = [
+      [topic: topic, partitions: [[partition: 0]]]
+    ]
+
+    request = offset_fetch_request(group_id, topics_data, vsn)
+
+    if vsn >= 6 do
+      %{request | tagged_fields: []}
+    else
+      request
+    end
+  end
+
+  # DeleteGroups request builder — handles all versions
+  defp build_delete_groups_request(group_ids, version) do
+    vsn = min(version, Kayrock.DeleteGroups.max_vsn())
+    request = delete_groups_request(group_ids, vsn)
+
+    if vsn >= 2 do
+      %{request | tagged_fields: []}
+    else
+      request
+    end
+  end
+
+  # OffsetDelete V0 request builder
+  defp build_offset_delete_request(group_id, topic) do
+    request = Kayrock.OffsetDelete.get_request_struct(0)
+
+    %{
+      request
+      | group_id: group_id,
+        topics: [
+          %{
+            name: topic,
+            partitions: [%{partition_index: 0}]
+          }
+        ]
+    }
+  end
+end

--- a/test/sanity/consumer_group_sanity_test.exs
+++ b/test/sanity/consumer_group_sanity_test.exs
@@ -291,27 +291,6 @@ defmodule Kayrock.Sanity.ConsumerGroupSanityTest do
       assert response.error_code == 0
     end
 
-    # V1+ has rebalance_timeout_ms in request
-    @tag api: :join_group, version: 1
-    test "V1+ request struct has rebalance_timeout_ms", %{topic: topic} do
-      request = build_join_group_request("test-rebalance-#{unique_string()}", topic, 1)
-
-      assert Map.has_key?(request, :rebalance_timeout_ms),
-             "V1+ request should have rebalance_timeout_ms"
-    end
-
-    # V5+ has group_instance_id in request
-    for version <- 5..6 do
-      @tag api: :join_group, version: version
-      test "V#{version} request struct has group_instance_id", %{topic: topic} do
-        version = unquote(version)
-        request = build_join_group_request("test-gi-#{unique_string()}", topic, version)
-
-        assert Map.has_key?(request, :group_instance_id),
-               "V#{version} request should have group_instance_id"
-      end
-    end
-
     # Sole member becomes the leader
     @tag api: :join_group
     test "sole member is the leader", %{client: client, topic: topic} do
@@ -359,18 +338,6 @@ defmodule Kayrock.Sanity.ConsumerGroupSanityTest do
       end
     end
 
-    # V3+ has group_instance_id in request
-    for version <- 3..4 do
-      @tag api: :sync_group, version: version
-      test "V#{version} request struct has group_instance_id", %{topic: topic} do
-        version = unquote(version)
-        request = Kayrock.SyncGroup.get_request_struct(version)
-
-        assert Map.has_key?(request, :group_instance_id),
-               "V#{version} SyncGroup request should have group_instance_id"
-      end
-    end
-
     # V4 has tagged_fields in request
     @tag api: :sync_group, version: 4
     test "V4 request has tagged_fields (flexible)", %{client: client, topic: topic} do
@@ -385,15 +352,6 @@ defmodule Kayrock.Sanity.ConsumerGroupSanityTest do
 
       {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
       assert response.error_code == 0
-    end
-
-    # V0 has no group_instance_id
-    @tag api: :sync_group, version: 0
-    test "V0 request struct has no group_instance_id" do
-      request = Kayrock.SyncGroup.get_request_struct(0)
-
-      refute Map.has_key?(request, :group_instance_id),
-             "V0 SyncGroup request should not have group_instance_id"
     end
   end
 
@@ -419,57 +377,6 @@ defmodule Kayrock.Sanity.ConsumerGroupSanityTest do
         assert response.error_code == 0,
                "V#{version} Heartbeat error_code should be 0, got #{response.error_code}"
       end
-    end
-
-    # V0-V2 have no group_instance_id; V3+ does have it
-    for version <- 0..2 do
-      @tag api: :heartbeat, version: version
-      test "V#{version} request struct has no group_instance_id" do
-        version = unquote(version)
-        request = Kayrock.Heartbeat.get_request_struct(version)
-
-        refute Map.has_key?(request, :group_instance_id),
-               "V#{version} Heartbeat request should not have group_instance_id"
-      end
-    end
-
-    # V3 has group_instance_id (but no tagged_fields yet)
-    @tag api: :heartbeat, version: 3
-    test "V3 request struct has group_instance_id" do
-      request = Kayrock.Heartbeat.get_request_struct(3)
-
-      assert Map.has_key?(request, :group_instance_id),
-             "V3 Heartbeat request should have group_instance_id"
-
-      refute Map.has_key?(request, :tagged_fields),
-             "V3 Heartbeat request should not have tagged_fields"
-    end
-
-    # V4 has group_instance_id and tagged_fields
-    @tag api: :heartbeat, version: 4
-    test "V4 request struct has group_instance_id and tagged_fields" do
-      request = Kayrock.Heartbeat.get_request_struct(4)
-
-      assert Map.has_key?(request, :group_instance_id),
-             "V4 Heartbeat request should have group_instance_id"
-
-      assert Map.has_key?(request, :tagged_fields),
-             "V4 Heartbeat request should have tagged_fields"
-    end
-
-    # Heartbeat with wrong generation_id should return ILLEGAL_GENERATION (22)
-    @tag api: :heartbeat
-    test "heartbeat with wrong generation_id returns error", %{client: client, topic: topic} do
-      ctx = join_and_sync_group(client, topic)
-      %{group_id: group_id, node_id: node_id, member_id: member_id} = ctx
-
-      # Use a clearly wrong generation id
-      request = heartbeat_request(group_id, member_id, 9_999_999, 2)
-      {:ok, response} = Kayrock.client_call(client, request, node_id)
-
-      # ILLEGAL_GENERATION(22) or UNKNOWN_MEMBER_ID(25) or REBALANCE_IN_PROGRESS(27)
-      assert response.error_code in [22, 25, 27],
-             "Expected error for bad generation_id, got #{response.error_code}"
     end
   end
 
@@ -499,21 +406,6 @@ defmodule Kayrock.Sanity.ConsumerGroupSanityTest do
       end
     end
 
-    # V0-V2 struct has member_id field
-    for version <- 0..2 do
-      @tag api: :leave_group, version: version
-      test "V#{version} request struct has member_id field" do
-        version = unquote(version)
-        request = Kayrock.LeaveGroup.get_request_struct(version)
-
-        assert Map.has_key?(request, :member_id),
-               "V#{version} LeaveGroup request should have member_id"
-
-        refute Map.has_key?(request, :members),
-               "V#{version} LeaveGroup request should NOT have members list"
-      end
-    end
-
     # V3-V4: uses members list, NOT member_id
     for version <- 3..4 do
       @tag api: :leave_group, version: version
@@ -533,30 +425,6 @@ defmodule Kayrock.Sanity.ConsumerGroupSanityTest do
         assert response.error_code == 0,
                "V#{version} LeaveGroup (members list) error_code should be 0, got #{response.error_code}"
       end
-    end
-
-    # V3-V4 struct has members list field, NOT member_id
-    for version <- 3..4 do
-      @tag api: :leave_group, version: version
-      test "V#{version} request struct has members list, no member_id" do
-        version = unquote(version)
-        request = Kayrock.LeaveGroup.get_request_struct(version)
-
-        assert Map.has_key?(request, :members),
-               "V#{version} LeaveGroup request should have members list"
-
-        refute Map.has_key?(request, :member_id),
-               "V#{version} LeaveGroup request should NOT have member_id (batch leave)"
-      end
-    end
-
-    # V4 has tagged_fields
-    @tag api: :leave_group, version: 4
-    test "V4 request struct has tagged_fields (flexible)" do
-      request = Kayrock.LeaveGroup.get_request_struct(4)
-
-      assert Map.has_key?(request, :tagged_fields),
-             "V4 LeaveGroup request should have tagged_fields"
     end
 
     # V3+ response has members list
@@ -632,18 +500,6 @@ defmodule Kayrock.Sanity.ConsumerGroupSanityTest do
       end
     end
 
-    # V5 is flexible — request has include_authorized_operations + tagged_fields
-    @tag api: :describe_groups, version: 5
-    test "V5 request struct has include_authorized_operations and tagged_fields" do
-      request = Kayrock.DescribeGroups.get_request_struct(5)
-
-      assert Map.has_key?(request, :include_authorized_operations),
-             "V5 request should have include_authorized_operations"
-
-      assert Map.has_key?(request, :tagged_fields),
-             "V5 request should have tagged_fields"
-    end
-
     # V5 response also has tagged_fields
     @tag api: :describe_groups, version: 5
     test "V5 response includes tagged_fields (flexible)", %{client: client, topic: topic} do
@@ -705,45 +561,6 @@ defmodule Kayrock.Sanity.ConsumerGroupSanityTest do
         assert partition_resp.error_code == 0,
                "V#{version} partition error_code should be 0, got #{partition_resp.error_code}"
       end
-    end
-
-    # V0 has no generation_id or member_id
-    @tag api: :offset_commit, version: 0
-    test "V0 request struct has no generation_id or member_id" do
-      request = Kayrock.OffsetCommit.get_request_struct(0)
-
-      refute Map.has_key?(request, :generation_id),
-             "V0 OffsetCommit request should not have generation_id"
-
-      refute Map.has_key?(request, :member_id),
-             "V0 OffsetCommit request should not have member_id"
-    end
-
-    # V1+ has generation_id and member_id
-    for version <- 1..8 do
-      @tag api: :offset_commit, version: version
-      test "V#{version} request struct has generation_id and member_id" do
-        version = unquote(version)
-        request = Kayrock.OffsetCommit.get_request_struct(version)
-
-        assert Map.has_key?(request, :generation_id),
-               "V#{version} OffsetCommit request should have generation_id"
-
-        assert Map.has_key?(request, :member_id),
-               "V#{version} OffsetCommit request should have member_id"
-      end
-    end
-
-    # V8 has group_instance_id and tagged_fields
-    @tag api: :offset_commit, version: 8
-    test "V8 request struct has group_instance_id and tagged_fields" do
-      request = Kayrock.OffsetCommit.get_request_struct(8)
-
-      assert Map.has_key?(request, :group_instance_id),
-             "V8 OffsetCommit request should have group_instance_id"
-
-      assert Map.has_key?(request, :tagged_fields),
-             "V8 OffsetCommit request should have tagged_fields"
     end
 
     # V1 has commit_timestamp in partition data (need special handling)
@@ -810,17 +627,6 @@ defmodule Kayrock.Sanity.ConsumerGroupSanityTest do
       end
     end
 
-    # V6 is flexible — tagged_fields in request and response
-    @tag api: :offset_fetch, version: 6
-    test "V6 request struct has tagged_fields",
-      do:
-        (
-          request = Kayrock.OffsetFetch.get_request_struct(6)
-
-          assert Map.has_key?(request, :tagged_fields),
-                 "V6 OffsetFetch request should have tagged_fields"
-        )
-
     # V6 response also has error_code at top level (introduced in V2)
     for version <- 2..6 do
       @tag api: :offset_fetch, version: version
@@ -881,36 +687,6 @@ defmodule Kayrock.Sanity.ConsumerGroupSanityTest do
                "V#{version} result.error_code should be 0 or 69, got #{result.error_code}"
       end
     end
-
-    # V0-V1 have no tagged_fields
-    for version <- 0..1 do
-      @tag api: :delete_groups, version: version
-      test "V#{version} request struct has no tagged_fields" do
-        version = unquote(version)
-        request = Kayrock.DeleteGroups.get_request_struct(version)
-
-        refute Map.has_key?(request, :tagged_fields),
-               "V#{version} DeleteGroups request should not have tagged_fields"
-      end
-    end
-
-    # V2 has tagged_fields
-    @tag api: :delete_groups, version: 2
-    test "V2 request struct has tagged_fields (flexible)" do
-      request = Kayrock.DeleteGroups.get_request_struct(2)
-
-      assert Map.has_key?(request, :tagged_fields),
-             "V2 DeleteGroups request should have tagged_fields"
-    end
-
-    # groups_names field
-    @tag api: :delete_groups
-    test "request struct has groups_names field" do
-      request = Kayrock.DeleteGroups.get_request_struct(0)
-
-      assert Map.has_key?(request, :groups_names),
-             "DeleteGroups request should have groups_names field"
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -947,17 +723,6 @@ defmodule Kayrock.Sanity.ConsumerGroupSanityTest do
 
       assert is_list(response.topics),
              "V0 OffsetDelete response should have topics list"
-    end
-
-    @tag api: :offset_delete, version: 0
-    test "V0 response has correct field layout" do
-      request = Kayrock.OffsetDelete.get_request_struct(0)
-
-      assert Map.has_key?(request, :group_id),
-             "V0 OffsetDelete request should have group_id"
-
-      assert Map.has_key?(request, :topics),
-             "V0 OffsetDelete request should have topics"
     end
   end
 

--- a/test/sanity/stateless_sanity_test.exs
+++ b/test/sanity/stateless_sanity_test.exs
@@ -82,28 +82,26 @@ defmodule Kayrock.Sanity.StatelessSanityTest do
   # ---------------------------------------------------------------------------
 
   describe "ApiVersions" do
+    # V3 provides unique flexible-header coverage (KIP-482/KIP-511).
+    # V0-V2 basic success tests are covered by test/integration/api_versions_test.exs.
+    @tag api: :api_versions, version: 3
+    test "V3 returns success and parseable response", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+
+      request = build_api_versions_request(3)
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert response.error_code == 0,
+             "V3 expected error_code 0, got #{response.error_code}"
+
+      assert is_list(response.api_keys),
+             "V3 api_keys should be a list"
+
+      assert response.api_keys != [],
+             "V3 broker should report at least one supported API"
+    end
+
     for version <- 0..3 do
-      @tag api: :api_versions, version: version
-      test "V#{version} returns success and parseable response", %{kafka: kafka} do
-        version = unquote(version)
-        {:ok, client} = build_client(kafka)
-
-        request = build_api_versions_request(version)
-        {:ok, response} = Kayrock.client_call(client, request, :random)
-
-        assert response.error_code == 0,
-               "V#{version} expected error_code 0, got #{response.error_code}"
-
-        assert is_integer(response.correlation_id),
-               "V#{version} correlation_id should be integer"
-
-        assert is_list(response.api_keys),
-               "V#{version} api_keys should be a list"
-
-        assert response.api_keys != [],
-               "V#{version} broker should report at least one supported API"
-      end
-
       @tag api: :api_versions, version: version
       test "V#{version} api_keys contain valid entries", %{kafka: kafka} do
         version = unquote(version)
@@ -177,7 +175,6 @@ defmodule Kayrock.Sanity.StatelessSanityTest do
       {:ok, response} = Kayrock.client_call(client, request, :random)
 
       assert response.error_code == 0
-      assert is_integer(response.correlation_id)
     end
 
     # The broker must report ApiVersions (key 18) in its own response
@@ -205,9 +202,6 @@ defmodule Kayrock.Sanity.StatelessSanityTest do
 
         request = build_metadata_request(version)
         {:ok, response} = Kayrock.client_call(client, request, :random)
-
-        assert is_integer(response.correlation_id),
-               "V#{version} correlation_id should be integer"
 
         assert is_list(response.brokers),
                "V#{version} brokers should be a list"
@@ -363,9 +357,6 @@ defmodule Kayrock.Sanity.StatelessSanityTest do
 
         assert response.error_code == 0,
                "V#{version} expected error_code 0, got #{response.error_code}"
-
-        assert is_integer(response.correlation_id),
-               "V#{version} correlation_id should be integer"
 
         assert is_list(response.groups),
                "V#{version} groups should be a list (may be empty)"

--- a/test/sanity/stateless_sanity_test.exs
+++ b/test/sanity/stateless_sanity_test.exs
@@ -1,0 +1,431 @@
+defmodule Kayrock.Sanity.StatelessSanityTest do
+  @moduledoc """
+  Sanity tests for stateless APIs — only a broker connection required.
+
+  Covers:
+  - ApiVersions V0-V3 (API key 18)
+  - Metadata V0-V9 (API key 3)
+  - ListGroups V0-V3 (API key 16)
+
+  Run with:
+      mix test.sanity test/sanity/stateless_sanity_test.exs
+  """
+  use Kayrock.SanityCase
+  use ExUnit.Case, async: false
+
+  import Kayrock.RequestFactory
+
+  container(:kafka, KafkaContainer.new(), shared: true)
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  # Build a minimal valid ApiVersions request for the given version.
+  defp build_api_versions_request(version) do
+    request = api_versions_request(version)
+
+    if version >= 3 do
+      %{
+        request
+        | client_software_name: "kayrock-sanity",
+          client_software_version: "test",
+          tagged_fields: []
+      }
+    else
+      request
+    end
+  end
+
+  # Build a minimal valid Metadata request for the given version.
+  # Uses an empty topic list (all versions except V0 support nil; V0 requires []).
+  defp build_metadata_request(version) do
+    # V0: topics must be a non-nil list (nil/all-topics added in V1+)
+    topics = if version == 0, do: [], else: nil
+
+    request = metadata_request(topics, version)
+
+    cond do
+      version >= 9 ->
+        %{
+          request
+          | tagged_fields: [],
+            include_cluster_authorized_operations: false,
+            include_topic_authorized_operations: false
+        }
+
+      version >= 8 ->
+        %{
+          request
+          | include_cluster_authorized_operations: false,
+            include_topic_authorized_operations: false
+        }
+
+      true ->
+        request
+    end
+  end
+
+  # Build a minimal valid ListGroups request for the given version.
+  defp build_list_groups_request(version) do
+    request = list_consumer_groups_request(version)
+
+    if version >= 3 do
+      %{request | tagged_fields: []}
+    else
+      request
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # ApiVersions V0-V3
+  # ---------------------------------------------------------------------------
+
+  describe "ApiVersions" do
+    for version <- 0..3 do
+      @tag api: :api_versions, version: version
+      test "V#{version} returns success and parseable response", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request = build_api_versions_request(version)
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert response.error_code == 0,
+               "V#{version} expected error_code 0, got #{response.error_code}"
+
+        assert is_integer(response.correlation_id),
+               "V#{version} correlation_id should be integer"
+
+        assert is_list(response.api_keys),
+               "V#{version} api_keys should be a list"
+
+        assert response.api_keys != [],
+               "V#{version} broker should report at least one supported API"
+      end
+
+      @tag api: :api_versions, version: version
+      test "V#{version} api_keys contain valid entries", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request = build_api_versions_request(version)
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        for api_entry <- response.api_keys do
+          assert is_integer(api_entry.api_key),
+                 "V#{version}: api_entry.api_key should be integer, got #{inspect(api_entry.api_key)}"
+
+          assert is_integer(api_entry.min_version),
+                 "V#{version}: api_entry.min_version should be integer"
+
+          assert is_integer(api_entry.max_version),
+                 "V#{version}: api_entry.max_version should be integer"
+
+          assert api_entry.max_version >= api_entry.min_version,
+                 "V#{version}: max_version (#{api_entry.max_version}) >= min_version (#{api_entry.min_version})"
+        end
+      end
+    end
+
+    # V0 has no throttle_time_ms field
+    @tag api: :api_versions, version: 0
+    test "V0 response has no throttle_time_ms field", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      request = build_api_versions_request(0)
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      refute Map.has_key?(response, :throttle_time_ms),
+             "V0 response should not have throttle_time_ms"
+    end
+
+    # V1/V2/V3 include throttle_time_ms
+    for version <- 1..3 do
+      @tag api: :api_versions, version: version
+      test "V#{version} response includes throttle_time_ms", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request = build_api_versions_request(version)
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert response.throttle_time_ms >= 0,
+               "V#{version} throttle_time_ms should be non-negative"
+      end
+    end
+
+    # V3 is flexible — response must also include tagged_fields
+    @tag api: :api_versions, version: 3
+    test "V3 response includes tagged_fields (flexible version)", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      request = build_api_versions_request(3)
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_list(response.tagged_fields),
+             "V3 response.tagged_fields should be a list (flexible version)"
+    end
+
+    # KIP-511: response header always uses v0 (no tagged_fields in header)
+    # regardless of request version. A wrong header parser would crash here.
+    @tag api: :api_versions
+    test "V3 request/response header round-trip per KIP-511", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      request = build_api_versions_request(3)
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert response.error_code == 0
+      assert is_integer(response.correlation_id)
+    end
+
+    # The broker must report ApiVersions (key 18) in its own response
+    @tag api: :api_versions
+    test "broker reports ApiVersions API (key 18) in V1 response", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      request = build_api_versions_request(1)
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      api_map = Map.new(response.api_keys, &{&1.api_key, &1})
+      assert Map.has_key?(api_map, 18), "broker should report ApiVersions (key 18)"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Metadata V0-V9
+  # ---------------------------------------------------------------------------
+
+  describe "Metadata" do
+    for version <- 0..9 do
+      @tag api: :metadata, version: version
+      test "V#{version} returns success and parseable response", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request = build_metadata_request(version)
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.correlation_id),
+               "V#{version} correlation_id should be integer"
+
+        assert is_list(response.brokers),
+               "V#{version} brokers should be a list"
+
+        assert response.brokers != [],
+               "V#{version} broker list should not be empty"
+      end
+
+      @tag api: :metadata, version: version
+      test "V#{version} broker entries have required fields", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request = build_metadata_request(version)
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        for broker <- response.brokers do
+          assert is_integer(broker.node_id),
+                 "V#{version}: broker.node_id should be integer"
+
+          assert is_binary(broker.host),
+                 "V#{version}: broker.host should be binary"
+
+          assert is_integer(broker.port),
+                 "V#{version}: broker.port should be integer"
+
+          assert broker.port > 0,
+                 "V#{version}: broker.port should be > 0, got #{broker.port}"
+        end
+      end
+    end
+
+    # V0 does not have cluster_id or controller_id
+    @tag api: :metadata, version: 0
+    test "V0 response has topics list", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      request = build_metadata_request(0)
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_list(response.topics)
+    end
+
+    # V1+ include controller_id
+    for version <- 1..9 do
+      @tag api: :metadata, version: version
+      test "V#{version} response includes controller_id", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request = build_metadata_request(version)
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.controller_id),
+               "V#{version} controller_id should be integer"
+
+        assert response.controller_id >= 0,
+               "V#{version} controller_id should be >= 0, got #{response.controller_id}"
+      end
+    end
+
+    # V2+ include cluster_id
+    for version <- 2..9 do
+      @tag api: :metadata, version: version
+      test "V#{version} response includes cluster_id", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request = build_metadata_request(version)
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_binary(response.cluster_id) or is_nil(response.cluster_id),
+               "V#{version} cluster_id should be binary or nil"
+      end
+    end
+
+    # V9 is flexible — response must include tagged_fields
+    @tag api: :metadata, version: 9
+    test "V9 response includes tagged_fields (flexible version)", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      request = build_metadata_request(9)
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_list(response.tagged_fields),
+             "V9 response.tagged_fields should be a list (flexible version)"
+    end
+
+    # V8+ include cluster_authorized_operations in response
+    for version <- 8..9 do
+      @tag api: :metadata, version: version
+      test "V#{version} response includes cluster_authorized_operations", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request = build_metadata_request(version)
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.cluster_authorized_operations),
+               "V#{version} cluster_authorized_operations should be integer"
+      end
+    end
+
+    # V1+ allow nil topics (all-topics request)
+    for version <- 1..9 do
+      @tag api: :metadata, version: version
+      test "V#{version} nil topics (all-topics) returns broker list", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request = metadata_request(nil, version)
+
+        request =
+          cond do
+            version >= 9 ->
+              %{
+                request
+                | tagged_fields: [],
+                  include_cluster_authorized_operations: false,
+                  include_topic_authorized_operations: false
+              }
+
+            version >= 8 ->
+              %{
+                request
+                | include_cluster_authorized_operations: false,
+                  include_topic_authorized_operations: false
+              }
+
+            true ->
+              request
+          end
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_list(response.brokers), "V#{version} nil-topics brokers should be a list"
+        assert is_list(response.topics), "V#{version} nil-topics topics should be a list"
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # ListGroups V0-V3
+  # ---------------------------------------------------------------------------
+
+  describe "ListGroups" do
+    for version <- 0..3 do
+      @tag api: :list_groups, version: version
+      test "V#{version} returns success and parseable response", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request = build_list_groups_request(version)
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert response.error_code == 0,
+               "V#{version} expected error_code 0, got #{response.error_code}"
+
+        assert is_integer(response.correlation_id),
+               "V#{version} correlation_id should be integer"
+
+        assert is_list(response.groups),
+               "V#{version} groups should be a list (may be empty)"
+      end
+    end
+
+    # V0 has no throttle_time_ms
+    @tag api: :list_groups, version: 0
+    test "V0 response has no throttle_time_ms field", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      request = build_list_groups_request(0)
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      refute Map.has_key?(response, :throttle_time_ms),
+             "V0 response should not have throttle_time_ms"
+    end
+
+    # V1/V2/V3 include throttle_time_ms
+    for version <- 1..3 do
+      @tag api: :list_groups, version: version
+      test "V#{version} response includes throttle_time_ms", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request = build_list_groups_request(version)
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert response.throttle_time_ms >= 0,
+               "V#{version} throttle_time_ms should be non-negative"
+      end
+    end
+
+    # V3 is flexible — response must include tagged_fields
+    @tag api: :list_groups, version: 3
+    test "V3 response includes tagged_fields (flexible version)", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      request = build_list_groups_request(3)
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_list(response.tagged_fields),
+             "V3 response.tagged_fields should be a list (flexible version)"
+    end
+
+    # When groups exist, verify their structure
+    @tag api: :list_groups
+    test "V2 groups entries have group_id and protocol_type when groups exist", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      request = build_list_groups_request(2)
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      for group <- response.groups do
+        assert is_binary(group.group_id),
+               "group_id should be a binary string"
+
+        assert is_binary(group.protocol_type),
+               "protocol_type should be a binary string"
+      end
+    end
+  end
+end

--- a/test/sanity/topic_sanity_test.exs
+++ b/test/sanity/topic_sanity_test.exs
@@ -1,0 +1,1390 @@
+defmodule Kayrock.Sanity.TopicSanityTest do
+  @moduledoc """
+  Sanity tests for topic-dependent APIs — a topic (and optionally produced messages)
+  must exist before these tests run.
+
+  Covers:
+  - CreateTopics V0-V5 (API key 19)
+  - DeleteTopics V0-V4 (API key 20)
+  - Produce V0-V8 (API key 0)
+  - Fetch V0-V11 (API key 1)
+  - ListOffsets V0-V5 (API key 2)
+  - DeleteRecords V0-V1 (API key 21)
+  - CreatePartitions V0-V1 (API key 37)
+  - OffsetForLeaderEpoch V0-V3 (API key 23)
+  - DescribeConfigs V0-V2 (API key 32)
+  - AlterConfigs V0-V1 (API key 33)
+  - IncrementalAlterConfigs V0-V1 (API key 44)
+
+  Run with:
+      mix test.sanity test/sanity/topic_sanity_test.exs
+  """
+  use Kayrock.SanityCase
+  use ExUnit.Case, async: false
+
+  import Kayrock.RequestFactory
+
+  container(:kafka, KafkaContainer.new(), shared: true)
+
+  # ---------------------------------------------------------------------------
+  # Shared setup: one topic with 3 partitions; one produced message (offset 0)
+  # ---------------------------------------------------------------------------
+
+  setup_all %{kafka: kafka} do
+    {:ok, client} = build_client(kafka)
+
+    # Create the shared topic using a high API version (falls back to max supported)
+    topic = create_topic(client, 5)
+    :ok = wait_for_topic(client, topic)
+
+    # Produce one message so Fetch / ListOffsets have data to read back
+    record_set = Kayrock.RecordBatch.from_binary_list(["sanity-check"])
+
+    produce_req =
+      produce_messages_request(
+        topic,
+        [[partition: 0, record_set: record_set]],
+        1,
+        5
+      )
+
+    {:ok, _produce_resp} = Kayrock.client_call(client, produce_req, :random)
+
+    %{client: client, topic: topic}
+  end
+
+  # ===========================================================================
+  # CreateTopics V0-V5
+  # ===========================================================================
+
+  describe "CreateTopics" do
+    # Each version test creates its OWN unique topic so the creation is the
+    # test.  We use `unique_string/0` from TestSupport (imported via SanityCase).
+    for version <- 0..5 do
+      @tag api: :create_topics, version: version
+      test "V#{version} creates a topic successfully", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        topic_name = unique_string()
+        request = create_topic_request(topic_name, version)
+        {:ok, response} = Kayrock.client_call(client, request, :controller)
+
+        assert is_integer(response.correlation_id),
+               "V#{version} correlation_id should be integer"
+
+        assert is_list(response.topics),
+               "V#{version} topics should be a list"
+
+        topic_result = Enum.find(response.topics, fn t -> t.name == topic_name end)
+        assert topic_result != nil, "V#{version} created topic should appear in response"
+
+        assert topic_result.error_code == 0,
+               "V#{version} topic creation error_code should be 0, got #{topic_result.error_code}"
+      end
+    end
+
+    # V0 response has no throttle_time_ms
+    @tag api: :create_topics, version: 0
+    test "V0 response has no throttle_time_ms", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      request = create_topic_request(unique_string(), 0)
+      {:ok, response} = Kayrock.client_call(client, request, :controller)
+
+      refute Map.has_key?(response, :throttle_time_ms),
+             "V0 CreateTopics response should not have throttle_time_ms"
+    end
+
+    # V2+ responses include throttle_time_ms
+    for version <- 2..5 do
+      @tag api: :create_topics, version: version
+      test "V#{version} response includes throttle_time_ms", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request = create_topic_request(unique_string(), version)
+        {:ok, response} = Kayrock.client_call(client, request, :controller)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert response.throttle_time_ms >= 0,
+               "V#{version} throttle_time_ms should be >= 0"
+      end
+    end
+
+    # V5 is flexible — response includes tagged_fields
+    @tag api: :create_topics, version: 5
+    test "V5 response includes tagged_fields (flexible version)", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      request = create_topic_request(unique_string(), 5)
+      {:ok, response} = Kayrock.client_call(client, request, :controller)
+
+      assert is_list(response.tagged_fields),
+             "V5 CreateTopics response.tagged_fields should be a list"
+    end
+
+    # Creating an already-existing topic should return error_code 36 (TOPIC_ALREADY_EXISTS)
+    @tag api: :create_topics
+    test "V3 creating duplicate topic returns TOPIC_ALREADY_EXISTS (36)", %{
+      kafka: kafka,
+      topic: topic
+    } do
+      {:ok, client} = build_client(kafka)
+      request = create_topic_request(topic, 3)
+      {:ok, response} = Kayrock.client_call(client, request, :controller)
+
+      topic_result = Enum.find(response.topics, fn t -> t.name == topic end)
+      assert topic_result != nil
+
+      # TOPIC_ALREADY_EXISTS = 36
+      assert topic_result.error_code == 36,
+             "Expected error_code 36 (TOPIC_ALREADY_EXISTS), got #{topic_result.error_code}"
+    end
+  end
+
+  # ===========================================================================
+  # DeleteTopics V0-V4
+  # ===========================================================================
+
+  describe "DeleteTopics" do
+    # Each version creates a throwaway topic, then deletes it.
+    for version <- 0..4 do
+      @tag api: :delete_topics, version: version
+      test "V#{version} deletes a topic successfully", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        # Create a throwaway topic (use high version; deletion version varies)
+        throwaway = create_topic(client, 5)
+        :ok = wait_for_topic(client, throwaway)
+
+        # Build delete request — topic_names is a plain list of strings
+        api_version = min(Kayrock.DeleteTopics.max_vsn(), version)
+        request = Kayrock.DeleteTopics.get_request_struct(api_version)
+
+        request =
+          if api_version >= 4 do
+            %{request | topic_names: [throwaway], timeout_ms: 5000, tagged_fields: []}
+          else
+            %{request | topic_names: [throwaway], timeout_ms: 5000}
+          end
+
+        {:ok, response} = Kayrock.client_call(client, request, :controller)
+
+        assert is_integer(response.correlation_id),
+               "V#{version} correlation_id should be integer"
+
+        assert is_list(response.responses),
+               "V#{version} responses should be a list"
+
+        topic_result = Enum.find(response.responses, fn r -> r.name == throwaway end)
+        assert topic_result != nil, "V#{version} deleted topic should appear in response"
+
+        assert topic_result.error_code == 0,
+               "V#{version} topic deletion error_code should be 0, got #{topic_result.error_code}"
+      end
+    end
+
+    # V0 response has no throttle_time_ms
+    @tag api: :delete_topics, version: 0
+    test "V0 response has no throttle_time_ms", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      throwaway = create_topic(client, 5)
+      :ok = wait_for_topic(client, throwaway)
+
+      request = Kayrock.DeleteTopics.get_request_struct(0)
+      request = %{request | topic_names: [throwaway], timeout_ms: 5000}
+      {:ok, response} = Kayrock.client_call(client, request, :controller)
+
+      refute Map.has_key?(response, :throttle_time_ms),
+             "V0 DeleteTopics response should not have throttle_time_ms"
+    end
+
+    # V1+ responses include throttle_time_ms
+    for version <- 1..4 do
+      @tag api: :delete_topics, version: version
+      test "V#{version} response includes throttle_time_ms", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+        throwaway = create_topic(client, 5)
+        :ok = wait_for_topic(client, throwaway)
+
+        api_version = min(Kayrock.DeleteTopics.max_vsn(), version)
+        request = Kayrock.DeleteTopics.get_request_struct(api_version)
+
+        request =
+          if api_version >= 4 do
+            %{request | topic_names: [throwaway], timeout_ms: 5000, tagged_fields: []}
+          else
+            %{request | topic_names: [throwaway], timeout_ms: 5000}
+          end
+
+        {:ok, response} = Kayrock.client_call(client, request, :controller)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+      end
+    end
+
+    # V4 is flexible — response includes tagged_fields
+    @tag api: :delete_topics, version: 4
+    test "V4 response includes tagged_fields (flexible version)", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      throwaway = create_topic(client, 5)
+      :ok = wait_for_topic(client, throwaway)
+
+      request = %Kayrock.DeleteTopics.V4.Request{
+        topic_names: [throwaway],
+        timeout_ms: 5000,
+        tagged_fields: []
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :controller)
+
+      assert is_list(response.tagged_fields),
+             "V4 DeleteTopics response.tagged_fields should be a list"
+    end
+  end
+
+  # ===========================================================================
+  # Produce V0-V8
+  # ===========================================================================
+
+  describe "Produce" do
+    # V0-V2 use MessageSet format
+    for version <- 0..2 do
+      @tag api: :produce, version: version
+      test "V#{version} produces a message (MessageSet format)", %{kafka: kafka, topic: topic} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        record_set = %Kayrock.MessageSet{
+          messages: [
+            %Kayrock.MessageSet.Message{key: nil, value: "msg-v#{version}", compression: :none}
+          ]
+        }
+
+        request =
+          produce_messages_request(topic, [[partition: 0, record_set: record_set]], 1, version)
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_list(response.responses),
+               "V#{version} responses should be a list"
+
+        assert response.responses != [],
+               "V#{version} responses should not be empty"
+
+        [topic_response] = response.responses
+        assert topic_response.topic == topic
+
+        [partition_response] = topic_response.partition_responses
+
+        assert partition_response.error_code == 0,
+               "V#{version} partition error_code should be 0, got #{partition_response.error_code}"
+
+        assert is_integer(partition_response.base_offset),
+               "V#{version} base_offset should be integer"
+      end
+    end
+
+    # V3+ use RecordBatch format
+    for version <- 3..8 do
+      @tag api: :produce, version: version
+      test "V#{version} produces a message (RecordBatch format)", %{kafka: kafka, topic: topic} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        record_set = Kayrock.RecordBatch.from_binary_list(["msg-v#{version}"])
+
+        request =
+          produce_messages_request(topic, [[partition: 0, record_set: record_set]], 1, version)
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_list(response.responses)
+        assert response.responses != []
+
+        [topic_response] = response.responses
+        assert topic_response.topic == topic
+
+        [partition_response] = topic_response.partition_responses
+
+        assert partition_response.error_code == 0,
+               "V#{version} partition error_code should be 0, got #{partition_response.error_code}"
+
+        assert is_integer(partition_response.base_offset),
+               "V#{version} base_offset should be integer"
+      end
+    end
+
+    # V0 response has no throttle_time_ms
+    @tag api: :produce, version: 0
+    test "V0 response has no throttle_time_ms", %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+
+      record_set = %Kayrock.MessageSet{
+        messages: [%Kayrock.MessageSet.Message{key: nil, value: "test", compression: :none}]
+      }
+
+      request = produce_messages_request(topic, [[partition: 0, record_set: record_set]], 1, 0)
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      refute Map.has_key?(response, :throttle_time_ms),
+             "V0 Produce response should not have throttle_time_ms"
+    end
+
+    # V1+ include throttle_time_ms
+    for version <- 1..8 do
+      @tag api: :produce, version: version
+      test "V#{version} response includes throttle_time_ms", %{kafka: kafka, topic: topic} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        record_set =
+          if version <= 2 do
+            %Kayrock.MessageSet{
+              messages: [
+                %Kayrock.MessageSet.Message{key: nil, value: "t", compression: :none}
+              ]
+            }
+          else
+            Kayrock.RecordBatch.from_binary_list(["t"])
+          end
+
+        request =
+          produce_messages_request(topic, [[partition: 0, record_set: record_set]], 1, version)
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert response.throttle_time_ms >= 0,
+               "V#{version} throttle_time_ms should be >= 0"
+      end
+    end
+
+    # V3+ include transactional_id field
+    for version <- 3..8 do
+      @tag api: :produce, version: version
+      test "V#{version} request struct has transactional_id field", %{kafka: kafka, topic: topic} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        record_set = Kayrock.RecordBatch.from_binary_list(["tx-test"])
+
+        request =
+          produce_messages_request(topic, [[partition: 0, record_set: record_set]], 1, version)
+
+        assert Map.has_key?(request, :transactional_id),
+               "V#{version} request should have transactional_id"
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+        assert is_list(response.responses)
+      end
+    end
+
+    # V8 response includes record_errors and error_message (KIP-467)
+    @tag api: :produce, version: 8
+    test "V8 response partition entries include record_errors and error_message", %{
+      kafka: kafka,
+      topic: topic
+    } do
+      {:ok, client} = build_client(kafka)
+      record_set = Kayrock.RecordBatch.from_binary_list(["v8-msg"])
+      request = produce_messages_request(topic, [[partition: 0, record_set: record_set]], 1, 8)
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      [topic_response] = response.responses
+      [partition_response] = topic_response.partition_responses
+
+      assert Map.has_key?(partition_response, :record_errors),
+             "V8 partition_response should have record_errors"
+
+      assert is_list(partition_response.record_errors),
+             "V8 partition_response.record_errors should be a list"
+
+      assert Map.has_key?(partition_response, :error_message),
+             "V8 partition_response should have error_message"
+    end
+  end
+
+  # ===========================================================================
+  # Fetch V0-V11
+  # ===========================================================================
+
+  describe "Fetch" do
+    for version <- 0..11 do
+      @tag api: :fetch, version: version
+      test "V#{version} fetches from topic and returns parseable response", %{
+        kafka: kafka,
+        topic: topic
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request =
+          fetch_messages_request(
+            [[topic: topic, partition: 0, fetch_offset: 0]],
+            [max_wait_time: 500, min_bytes: 0],
+            version
+          )
+
+        # V9+ requires current_leader_epoch in each partition sub-map
+        request =
+          if version >= 9 do
+            updated_topics =
+              Enum.map(request.topics, fn topic_entry ->
+                updated_partitions =
+                  Enum.map(topic_entry.partitions, fn p ->
+                    Map.put_new(p, :current_leader_epoch, -1)
+                  end)
+
+                %{topic_entry | partitions: updated_partitions}
+              end)
+
+            %{request | topics: updated_topics}
+          else
+            request
+          end
+
+        # V11 requires rack_id (non-nullable string)
+        request =
+          if version >= 11, do: %{request | rack_id: ""}, else: request
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.correlation_id),
+               "V#{version} correlation_id should be integer"
+
+        assert is_list(response.responses),
+               "V#{version} responses should be a list"
+      end
+    end
+
+    # V0 has no throttle_time_ms
+    @tag api: :fetch, version: 0
+    test "V0 response has no throttle_time_ms", %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+
+      request =
+        fetch_messages_request(
+          [[topic: topic, partition: 0, fetch_offset: 0]],
+          [max_wait_time: 500, min_bytes: 0],
+          0
+        )
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      refute Map.has_key?(response, :throttle_time_ms),
+             "V0 Fetch response should not have throttle_time_ms"
+    end
+
+    # V1+ include throttle_time_ms
+    for version <- 1..11 do
+      @tag api: :fetch, version: version
+      test "V#{version} response includes throttle_time_ms", %{kafka: kafka, topic: topic} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request =
+          fetch_messages_request(
+            [[topic: topic, partition: 0, fetch_offset: 0]],
+            [max_wait_time: 500, min_bytes: 0],
+            version
+          )
+
+        # V9+ requires current_leader_epoch in each partition sub-map
+        request =
+          if version >= 9 do
+            updated_topics =
+              Enum.map(request.topics, fn topic_entry ->
+                updated_partitions =
+                  Enum.map(topic_entry.partitions, fn p ->
+                    Map.put_new(p, :current_leader_epoch, -1)
+                  end)
+
+                %{topic_entry | partitions: updated_partitions}
+              end)
+
+            %{request | topics: updated_topics}
+          else
+            request
+          end
+
+        # V11 requires rack_id (non-nullable string)
+        request =
+          if version >= 11, do: %{request | rack_id: ""}, else: request
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert response.throttle_time_ms >= 0,
+               "V#{version} throttle_time_ms should be >= 0"
+      end
+    end
+
+    # Verify topic appears in response with error_code 0
+    for version <- [0, 4, 7, 11] do
+      @tag api: :fetch, version: version
+      test "V#{version} response contains topic with error_code 0", %{
+        kafka: kafka,
+        topic: topic
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request =
+          fetch_messages_request(
+            [[topic: topic, partition: 0, fetch_offset: 0]],
+            [max_wait_time: 500, min_bytes: 0],
+            version
+          )
+
+        # V9+ requires current_leader_epoch in each partition sub-map
+        request =
+          if version >= 9 do
+            updated_topics =
+              Enum.map(request.topics, fn topic_entry ->
+                updated_partitions =
+                  Enum.map(topic_entry.partitions, fn p ->
+                    Map.put_new(p, :current_leader_epoch, -1)
+                  end)
+
+                %{topic_entry | partitions: updated_partitions}
+              end)
+
+            %{request | topics: updated_topics}
+          else
+            request
+          end
+
+        # V11 requires rack_id (non-nullable string)
+        request =
+          if version >= 11, do: %{request | rack_id: ""}, else: request
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert response.responses != [],
+               "V#{version} fetch should return at least one topic response"
+
+        [topic_resp | _] = response.responses
+        [partition_resp | _] = topic_resp.partition_responses
+
+        assert partition_resp.partition_header.error_code == 0,
+               "V#{version} partition error_code should be 0, got #{partition_resp.partition_header.error_code}"
+      end
+    end
+
+    # V7+ use session_id / session_epoch
+    for version <- 7..11 do
+      @tag api: :fetch, version: version
+      test "V#{version} request struct has session_id and session_epoch fields", %{
+        kafka: kafka,
+        topic: topic
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request =
+          fetch_messages_request(
+            [[topic: topic, partition: 0, fetch_offset: 0]],
+            [max_wait_time: 500, min_bytes: 0],
+            version
+          )
+
+        # V9+ requires current_leader_epoch in each partition sub-map
+        request =
+          if version >= 9 do
+            updated_topics =
+              Enum.map(request.topics, fn topic_entry ->
+                updated_partitions =
+                  Enum.map(topic_entry.partitions, fn p ->
+                    Map.put_new(p, :current_leader_epoch, -1)
+                  end)
+
+                %{topic_entry | partitions: updated_partitions}
+              end)
+
+            %{request | topics: updated_topics}
+          else
+            request
+          end
+
+        # V11 requires rack_id (non-nullable string)
+        request =
+          if version >= 11, do: %{request | rack_id: ""}, else: request
+
+        assert Map.has_key?(request, :session_id),
+               "V#{version} request should have session_id"
+
+        assert Map.has_key?(request, :session_epoch),
+               "V#{version} request should have session_epoch"
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+        assert is_list(response.responses)
+      end
+    end
+  end
+
+  # ===========================================================================
+  # ListOffsets V0-V5
+  # ===========================================================================
+
+  describe "ListOffsets" do
+    for version <- 0..5 do
+      @tag api: :list_offsets, version: version
+      test "V#{version} returns parseable response", %{kafka: kafka, topic: topic} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request =
+          list_offsets_request(
+            topic,
+            [[partition: 0, timestamp: -1]],
+            version
+          )
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.correlation_id),
+               "V#{version} correlation_id should be integer"
+
+        assert is_list(response.responses),
+               "V#{version} responses should be a list"
+
+        assert response.responses != [],
+               "V#{version} responses should not be empty"
+      end
+    end
+
+    # V0 response has no throttle_time_ms
+    @tag api: :list_offsets, version: 0
+    test "V0 response has no throttle_time_ms", %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+      request = list_offsets_request(topic, [[partition: 0, timestamp: -1]], 0)
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      refute Map.has_key?(response, :throttle_time_ms),
+             "V0 ListOffsets response should not have throttle_time_ms"
+    end
+
+    # V2+ include throttle_time_ms
+    for version <- 2..5 do
+      @tag api: :list_offsets, version: version
+      test "V#{version} response includes throttle_time_ms", %{kafka: kafka, topic: topic} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request = list_offsets_request(topic, [[partition: 0, timestamp: -1]], version)
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert response.throttle_time_ms >= 0,
+               "V#{version} throttle_time_ms should be >= 0"
+      end
+    end
+
+    # Verify partition response structure
+    for version <- [0, 1, 5] do
+      @tag api: :list_offsets, version: version
+      test "V#{version} partition response has offset and error_code", %{
+        kafka: kafka,
+        topic: topic
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request = list_offsets_request(topic, [[partition: 0, timestamp: -1]], version)
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        [topic_response] = response.responses
+        [partition_response] = topic_response.partition_responses
+
+        assert is_integer(partition_response.error_code),
+               "V#{version} partition error_code should be integer"
+
+        assert partition_response.error_code == 0,
+               "V#{version} partition error_code should be 0, got #{partition_response.error_code}"
+      end
+    end
+
+    # V0 uses max_num_offsets (old format); V1+ returns single offset
+    @tag api: :list_offsets, version: 0
+    test "V0 partition response has offsets list (old format)", %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+      request = list_offsets_request(topic, [[partition: 0, timestamp: -2]], 0)
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      [topic_response] = response.responses
+      [partition_response] = topic_response.partition_responses
+
+      assert is_list(partition_response.offsets),
+             "V0 ListOffsets partition_response should have offsets list"
+    end
+
+    # V1+ response returns a single offset (int64)
+    @tag api: :list_offsets, version: 1
+    test "V1 partition response has timestamp and offset fields", %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+      request = list_offsets_request(topic, [[partition: 0, timestamp: -1]], 1)
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      [topic_response] = response.responses
+      [partition_response] = topic_response.partition_responses
+
+      assert Map.has_key?(partition_response, :timestamp),
+             "V1 partition_response should have timestamp"
+
+      assert Map.has_key?(partition_response, :offset),
+             "V1 partition_response should have offset"
+    end
+  end
+
+  # ===========================================================================
+  # DeleteRecords V0-V1
+  # ===========================================================================
+
+  describe "DeleteRecords" do
+    for version <- 0..1 do
+      @tag api: :delete_records, version: version
+      test "V#{version} deletes records up to offset 0 and returns success", %{
+        kafka: kafka,
+        topic: topic
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        api_version = min(Kayrock.DeleteRecords.max_vsn(), version)
+        request = Kayrock.DeleteRecords.get_request_struct(api_version)
+
+        request = %{
+          request
+          | topics: [
+              %{
+                topic: topic,
+                partitions: [%{partition: 0, offset: 0}]
+              }
+            ],
+            timeout: 5000
+        }
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert is_list(response.topics),
+               "V#{version} topics should be a list"
+
+        topic_resp = Enum.find(response.topics, fn t -> t.topic == topic end)
+        assert topic_resp != nil, "V#{version} topic should appear in response"
+
+        [partition_resp] = topic_resp.partitions
+
+        assert partition_resp.error_code == 0,
+               "V#{version} partition error_code should be 0, got #{partition_resp.error_code}"
+      end
+    end
+
+    # Verify throttle_time_ms in both versions
+    for version <- 0..1 do
+      @tag api: :delete_records, version: version
+      test "V#{version} response includes throttle_time_ms", %{kafka: kafka, topic: topic} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        api_version = min(Kayrock.DeleteRecords.max_vsn(), version)
+        request = Kayrock.DeleteRecords.get_request_struct(api_version)
+
+        request = %{
+          request
+          | topics: [
+              %{
+                topic: topic,
+                partitions: [%{partition: 0, offset: 0}]
+              }
+            ],
+            timeout: 5000
+        }
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert response.throttle_time_ms >= 0
+      end
+    end
+  end
+
+  # ===========================================================================
+  # CreatePartitions V0-V1
+  # ===========================================================================
+
+  describe "CreatePartitions" do
+    # Create a fresh topic for each partition-increase test to avoid conflicts
+    for version <- 0..1 do
+      @tag api: :create_partitions, version: version
+      test "V#{version} increases partition count and returns success", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        # Create a single-partition topic for this test
+        topic_name = unique_string()
+        # Create with 1 partition by using custom create request
+        create_req = Kayrock.CreateTopics.get_request_struct(3)
+
+        create_req = %{
+          create_req
+          | topics: [
+              %{
+                name: topic_name,
+                num_partitions: 1,
+                replication_factor: 1,
+                assignments: [],
+                configs: []
+              }
+            ],
+            timeout_ms: 5000,
+            validate_only: false
+        }
+
+        {:ok, _} = Kayrock.client_call(client, create_req, :controller)
+        :ok = wait_for_topic(client, topic_name)
+
+        # Now increase to 3 partitions
+        api_version = min(Kayrock.CreatePartitions.max_vsn(), version)
+        request = Kayrock.CreatePartitions.get_request_struct(api_version)
+
+        request = %{
+          request
+          | topic_partitions: [
+              %{
+                topic: topic_name,
+                new_partitions: %{count: 3, assignment: nil}
+              }
+            ],
+            timeout: 5000,
+            validate_only: false
+        }
+
+        {:ok, response} = Kayrock.client_call(client, request, :controller)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert is_list(response.topic_errors),
+               "V#{version} topic_errors should be a list"
+
+        topic_result = Enum.find(response.topic_errors, fn t -> t.topic == topic_name end)
+        assert topic_result != nil
+
+        assert topic_result.error_code == 0,
+               "V#{version} topic_errors error_code should be 0, got #{topic_result.error_code}"
+      end
+    end
+
+    # Verify response structure has topic_errors (not results)
+    @tag api: :create_partitions, version: 0
+    test "V0 response has topic_errors field (not results)", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      topic_name = unique_string()
+
+      create_req = Kayrock.CreateTopics.get_request_struct(3)
+
+      create_req = %{
+        create_req
+        | topics: [
+            %{
+              name: topic_name,
+              num_partitions: 1,
+              replication_factor: 1,
+              assignments: [],
+              configs: []
+            }
+          ],
+          timeout_ms: 5000,
+          validate_only: false
+      }
+
+      {:ok, _} = Kayrock.client_call(client, create_req, :controller)
+      :ok = wait_for_topic(client, topic_name)
+
+      request = %Kayrock.CreatePartitions.V0.Request{
+        topic_partitions: [%{topic: topic_name, new_partitions: %{count: 3, assignment: nil}}],
+        timeout: 5000,
+        validate_only: false
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :controller)
+
+      assert Map.has_key?(response, :topic_errors),
+             "V0 CreatePartitions response should have topic_errors field"
+
+      refute Map.has_key?(response, :results),
+             "V0 CreatePartitions response should NOT have results field"
+    end
+  end
+
+  # ===========================================================================
+  # OffsetForLeaderEpoch V0-V3
+  # ===========================================================================
+
+  describe "OffsetForLeaderEpoch" do
+    # V0/V1: topics + partitions with leader_epoch only
+    for version <- 0..1 do
+      @tag api: :offset_for_leader_epoch, version: version
+      test "V#{version} returns parseable response", %{kafka: kafka, topic: topic} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        api_version = min(Kayrock.OffsetForLeaderEpoch.max_vsn(), version)
+        request = Kayrock.OffsetForLeaderEpoch.get_request_struct(api_version)
+
+        request = %{
+          request
+          | topics: [
+              %{
+                topic: topic,
+                partitions: [%{partition: 0, leader_epoch: 0}]
+              }
+            ]
+        }
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.correlation_id),
+               "V#{version} correlation_id should be integer"
+
+        assert is_list(response.topics),
+               "V#{version} topics should be a list"
+      end
+    end
+
+    # V2: topics + partitions with current_leader_epoch + leader_epoch (no replica_id)
+    @tag api: :offset_for_leader_epoch, version: 2
+    test "V2 returns parseable response", %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+
+      request = Kayrock.OffsetForLeaderEpoch.get_request_struct(2)
+
+      request = %{
+        request
+        | topics: [
+            %{
+              topic: topic,
+              partitions: [%{partition: 0, current_leader_epoch: -1, leader_epoch: 0}]
+            }
+          ]
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_integer(response.correlation_id)
+      assert is_list(response.topics)
+    end
+
+    # V3: adds replica_id field
+    @tag api: :offset_for_leader_epoch, version: 3
+    test "V3 request has replica_id field and returns parseable response", %{
+      kafka: kafka,
+      topic: topic
+    } do
+      {:ok, client} = build_client(kafka)
+
+      request = Kayrock.OffsetForLeaderEpoch.get_request_struct(3)
+
+      request = %{
+        request
+        | replica_id: -1,
+          topics: [
+            %{
+              topic: topic,
+              partitions: [%{partition: 0, current_leader_epoch: -1, leader_epoch: 0}]
+            }
+          ]
+      }
+
+      assert Map.has_key?(request, :replica_id),
+             "V3 OffsetForLeaderEpoch request should have replica_id"
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_integer(response.correlation_id)
+      assert is_list(response.topics)
+    end
+
+    # V0 response has no throttle_time_ms
+    @tag api: :offset_for_leader_epoch, version: 0
+    test "V0 response has no throttle_time_ms", %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.OffsetForLeaderEpoch.V0.Request{
+        topics: [
+          %{topic: topic, partitions: [%{partition: 0, leader_epoch: 0}]}
+        ]
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      refute Map.has_key?(response, :throttle_time_ms),
+             "V0 OffsetForLeaderEpoch response should not have throttle_time_ms"
+    end
+
+    # V2+ include throttle_time_ms
+    for version <- 2..3 do
+      @tag api: :offset_for_leader_epoch, version: version
+      test "V#{version} response includes throttle_time_ms", %{kafka: kafka, topic: topic} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        api_version = min(Kayrock.OffsetForLeaderEpoch.max_vsn(), version)
+        request = Kayrock.OffsetForLeaderEpoch.get_request_struct(api_version)
+
+        request = %{
+          request
+          | topics: [
+              %{
+                topic: topic,
+                partitions: [%{partition: 0, current_leader_epoch: -1, leader_epoch: 0}]
+              }
+            ]
+        }
+
+        request =
+          if api_version >= 3 do
+            %{request | replica_id: -1}
+          else
+            request
+          end
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+      end
+    end
+  end
+
+  # ===========================================================================
+  # DescribeConfigs V0-V2
+  # ===========================================================================
+
+  describe "DescribeConfigs" do
+    # resource_type 2 = TOPIC
+    for version <- 0..2 do
+      @tag api: :describe_configs, version: version
+      test "V#{version} describes topic config and returns parseable response", %{
+        kafka: kafka,
+        topic: topic
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        api_version = min(Kayrock.DescribeConfigs.max_vsn(), version)
+        request = Kayrock.DescribeConfigs.get_request_struct(api_version)
+
+        resource = %{
+          resource_type: 2,
+          resource_name: topic,
+          config_names: []
+        }
+
+        request =
+          if api_version >= 1 do
+            %{request | resources: [resource], include_synonyms: false}
+          else
+            %{request | resources: [resource]}
+          end
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert is_list(response.resources),
+               "V#{version} resources should be a list"
+
+        assert response.resources != [],
+               "V#{version} resources should not be empty"
+      end
+    end
+
+    # Verify resource entry structure
+    for version <- [0, 2] do
+      @tag api: :describe_configs, version: version
+      test "V#{version} resource entry has error_code and configs", %{
+        kafka: kafka,
+        topic: topic
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        api_version = min(Kayrock.DescribeConfigs.max_vsn(), version)
+        request = Kayrock.DescribeConfigs.get_request_struct(api_version)
+
+        resource = %{resource_type: 2, resource_name: topic, config_names: []}
+
+        request =
+          if api_version >= 1 do
+            %{request | resources: [resource], include_synonyms: false}
+          else
+            %{request | resources: [resource]}
+          end
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        [resource_result] = response.resources
+
+        assert is_integer(resource_result.error_code),
+               "V#{version} resource_result.error_code should be integer"
+
+        assert resource_result.error_code == 0,
+               "V#{version} resource error_code should be 0, got #{resource_result.error_code}"
+
+        assert is_list(resource_result.config_entries),
+               "V#{version} resource_result.config_entries should be a list"
+      end
+    end
+
+    # V1+ supports include_synonyms
+    @tag api: :describe_configs, version: 1
+    test "V1 include_synonyms field accepted without error", %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.DescribeConfigs.V1.Request{
+        resources: [%{resource_type: 2, resource_name: topic, config_names: []}],
+        include_synonyms: true
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_list(response.resources)
+    end
+  end
+
+  # ===========================================================================
+  # AlterConfigs V0-V1
+  # ===========================================================================
+
+  describe "AlterConfigs" do
+    # resource_type 2 = TOPIC; set retention.ms to a valid value
+    for version <- 0..1 do
+      @tag api: :alter_configs, version: version
+      test "V#{version} alters topic config and returns success", %{
+        kafka: kafka,
+        topic: topic
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        api_version = min(Kayrock.AlterConfigs.max_vsn(), version)
+        request = Kayrock.AlterConfigs.get_request_struct(api_version)
+
+        request = %{
+          request
+          | resources: [
+              %{
+                resource_type: 2,
+                resource_name: topic,
+                config_entries: [%{config_name: "retention.ms", config_value: "604800000"}]
+              }
+            ],
+            validate_only: false
+        }
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert is_list(response.resources),
+               "V#{version} resources should be a list"
+      end
+    end
+
+    # Verify resource entry has error_code 0
+    for version <- 0..1 do
+      @tag api: :alter_configs, version: version
+      test "V#{version} resource entry has error_code 0", %{kafka: kafka, topic: topic} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        api_version = min(Kayrock.AlterConfigs.max_vsn(), version)
+        request = Kayrock.AlterConfigs.get_request_struct(api_version)
+
+        request = %{
+          request
+          | resources: [
+              %{
+                resource_type: 2,
+                resource_name: topic,
+                config_entries: [%{config_name: "retention.ms", config_value: "604800001"}]
+              }
+            ],
+            validate_only: false
+        }
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        [resource_result] = response.resources
+
+        assert is_integer(resource_result.error_code),
+               "V#{version} resource_result.error_code should be integer"
+
+        assert resource_result.error_code == 0,
+               "V#{version} resource error_code should be 0, got #{resource_result.error_code}"
+      end
+    end
+  end
+
+  # ===========================================================================
+  # IncrementalAlterConfigs V0-V1
+  # ===========================================================================
+
+  describe "IncrementalAlterConfigs" do
+    # config_operation 0 = SET
+    for version <- 0..1 do
+      @tag api: :incremental_alter_configs, version: version
+      test "V#{version} incrementally alters topic config and returns success", %{
+        kafka: kafka,
+        topic: topic
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        api_version = min(Kayrock.IncrementalAlterConfigs.max_vsn(), version)
+        request = Kayrock.IncrementalAlterConfigs.get_request_struct(api_version)
+
+        resource = %{
+          resource_type: 2,
+          resource_name: topic,
+          configs: [%{name: "retention.ms", config_operation: 0, value: "86400000"}]
+        }
+
+        request =
+          if api_version >= 1 do
+            %{
+              request
+              | resources: [Map.put(resource, :tagged_fields, [])],
+                validate_only: false,
+                tagged_fields: []
+            }
+          else
+            %{request | resources: [resource], validate_only: false}
+          end
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert is_list(response.responses),
+               "V#{version} responses should be a list"
+      end
+    end
+
+    # Verify response has responses field (not resources)
+    @tag api: :incremental_alter_configs, version: 0
+    test "V0 response has responses field (not resources)", %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.IncrementalAlterConfigs.V0.Request{
+        resources: [
+          %{
+            resource_type: 2,
+            resource_name: topic,
+            configs: [%{name: "retention.ms", config_operation: 0, value: "86400001"}]
+          }
+        ],
+        validate_only: false
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert Map.has_key?(response, :responses),
+             "V0 IncrementalAlterConfigs response should have responses field"
+
+      refute Map.has_key?(response, :resources),
+             "V0 IncrementalAlterConfigs response should NOT have resources field"
+    end
+
+    # V1 is flexible — response includes tagged_fields
+    @tag api: :incremental_alter_configs, version: 1
+    test "V1 response includes tagged_fields (flexible version)", %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+
+      request = %Kayrock.IncrementalAlterConfigs.V1.Request{
+        resources: [
+          %{
+            resource_type: 2,
+            resource_name: topic,
+            configs: [
+              %{
+                name: "retention.ms",
+                config_operation: 0,
+                value: "86400002",
+                tagged_fields: []
+              }
+            ],
+            tagged_fields: []
+          }
+        ],
+        validate_only: false,
+        tagged_fields: []
+      }
+
+      {:ok, response} = Kayrock.client_call(client, request, :random)
+
+      assert is_list(response.tagged_fields),
+             "V1 IncrementalAlterConfigs response.tagged_fields should be a list"
+    end
+
+    # Error case: response entry error_code should be 0 on success
+    for version <- 0..1 do
+      @tag api: :incremental_alter_configs, version: version
+      test "V#{version} response entry has error_code 0", %{kafka: kafka, topic: topic} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        api_version = min(Kayrock.IncrementalAlterConfigs.max_vsn(), version)
+        request = Kayrock.IncrementalAlterConfigs.get_request_struct(api_version)
+
+        resource = %{
+          resource_type: 2,
+          resource_name: topic,
+          configs: [%{name: "retention.ms", config_operation: 0, value: "86400003"}]
+        }
+
+        request =
+          if api_version >= 1 do
+            %{
+              request
+              | resources: [Map.put(resource, :tagged_fields, [])],
+                validate_only: false,
+                tagged_fields: []
+            }
+          else
+            %{request | resources: [resource], validate_only: false}
+          end
+
+        {:ok, response} = Kayrock.client_call(client, request, :random)
+
+        [result] = response.responses
+
+        assert is_integer(result.error_code),
+               "V#{version} response entry error_code should be integer"
+
+        assert result.error_code == 0,
+               "V#{version} response entry error_code should be 0, got #{result.error_code}"
+      end
+    end
+  end
+end

--- a/test/sanity/topic_sanity_test.exs
+++ b/test/sanity/topic_sanity_test.exs
@@ -70,9 +70,6 @@ defmodule Kayrock.Sanity.TopicSanityTest do
         request = create_topic_request(topic_name, version)
         {:ok, response} = Kayrock.client_call(client, request, :controller)
 
-        assert is_integer(response.correlation_id),
-               "V#{version} correlation_id should be integer"
-
         assert is_list(response.topics),
                "V#{version} topics should be a list"
 
@@ -171,9 +168,6 @@ defmodule Kayrock.Sanity.TopicSanityTest do
           end
 
         {:ok, response} = Kayrock.client_call(client, request, :controller)
-
-        assert is_integer(response.correlation_id),
-               "V#{version} correlation_id should be integer"
 
         assert is_list(response.responses),
                "V#{version} responses should be a list"
@@ -456,9 +450,6 @@ defmodule Kayrock.Sanity.TopicSanityTest do
 
         {:ok, response} = Kayrock.client_call(client, request, :random)
 
-        assert is_integer(response.correlation_id),
-               "V#{version} correlation_id should be integer"
-
         assert is_list(response.responses),
                "V#{version} responses should be a list"
       end
@@ -651,9 +642,6 @@ defmodule Kayrock.Sanity.TopicSanityTest do
 
         {:ok, response} = Kayrock.client_call(client, request, :random)
 
-        assert is_integer(response.correlation_id),
-               "V#{version} correlation_id should be integer"
-
         assert is_list(response.responses),
                "V#{version} responses should be a list"
 
@@ -780,6 +768,9 @@ defmodule Kayrock.Sanity.TopicSanityTest do
         assert is_integer(response.throttle_time_ms),
                "V#{version} throttle_time_ms should be integer"
 
+        assert response.throttle_time_ms >= 0,
+               "V#{version} throttle_time_ms should be >= 0"
+
         assert is_list(response.topics),
                "V#{version} topics should be a list"
 
@@ -790,36 +781,6 @@ defmodule Kayrock.Sanity.TopicSanityTest do
 
         assert partition_resp.error_code == 0,
                "V#{version} partition error_code should be 0, got #{partition_resp.error_code}"
-      end
-    end
-
-    # Verify throttle_time_ms in both versions
-    for version <- 0..1 do
-      @tag api: :delete_records, version: version
-      test "V#{version} response includes throttle_time_ms", %{kafka: kafka, topic: topic} do
-        version = unquote(version)
-        {:ok, client} = build_client(kafka)
-
-        api_version = min(Kayrock.DeleteRecords.max_vsn(), version)
-        request = Kayrock.DeleteRecords.get_request_struct(api_version)
-
-        request = %{
-          request
-          | topics: [
-              %{
-                topic: topic,
-                partitions: [%{partition: 0, offset: 0}]
-              }
-            ],
-            timeout: 5000
-        }
-
-        {:ok, response} = Kayrock.client_call(client, request, :random)
-
-        assert is_integer(response.throttle_time_ms),
-               "V#{version} throttle_time_ms should be integer"
-
-        assert response.throttle_time_ms >= 0
       end
     end
   end
@@ -960,9 +921,6 @@ defmodule Kayrock.Sanity.TopicSanityTest do
 
         {:ok, response} = Kayrock.client_call(client, request, :random)
 
-        assert is_integer(response.correlation_id),
-               "V#{version} correlation_id should be integer"
-
         assert is_list(response.topics),
                "V#{version} topics should be a list"
       end
@@ -987,7 +945,6 @@ defmodule Kayrock.Sanity.TopicSanityTest do
 
       {:ok, response} = Kayrock.client_call(client, request, :random)
 
-      assert is_integer(response.correlation_id)
       assert is_list(response.topics)
     end
 
@@ -1017,7 +974,6 @@ defmodule Kayrock.Sanity.TopicSanityTest do
 
       {:ok, response} = Kayrock.client_call(client, request, :random)
 
-      assert is_integer(response.correlation_id)
       assert is_list(response.topics)
     end
 

--- a/test/sanity/transaction_sanity_test.exs
+++ b/test/sanity/transaction_sanity_test.exs
@@ -433,7 +433,6 @@ defmodule Kayrock.Sanity.TransactionSanityTest do
         end_txn(client, 0, txn_id, producer_id, producer_epoch, false, node_id)
       end
     end
-
   end
 
   # ---------------------------------------------------------------------------
@@ -509,7 +508,6 @@ defmodule Kayrock.Sanity.TransactionSanityTest do
         assert response.throttle_time_ms >= 0
       end
     end
-
   end
 
   # ---------------------------------------------------------------------------
@@ -615,7 +613,6 @@ defmodule Kayrock.Sanity.TransactionSanityTest do
         end_txn(client, 0, txn_id, producer_id, producer_epoch, true, node_id)
       end
     end
-
 
     @tag api: :txn_offset_commit
     test "V2 adds committed_leader_epoch in partition entry", %{kafka: kafka, topic: topic} do

--- a/test/sanity/transaction_sanity_test.exs
+++ b/test/sanity/transaction_sanity_test.exs
@@ -434,31 +434,6 @@ defmodule Kayrock.Sanity.TransactionSanityTest do
       end
     end
 
-    @tag api: :add_offsets_to_txn
-    test "V0 response has correlation_id", %{kafka: kafka, topic: topic} do
-      {:ok, client} = build_client(kafka)
-      group_id = "txn-cid-group-#{unique_string()}"
-      {producer_id, producer_epoch, txn_id, node_id} = init_producer(client, 0, "add-offs-cid")
-
-      {:ok, _} =
-        add_partitions_to_txn(
-          client,
-          0,
-          txn_id,
-          producer_id,
-          producer_epoch,
-          [{topic, [0]}],
-          node_id
-        )
-
-      {:ok, response} =
-        add_offsets_to_txn(client, 0, txn_id, producer_id, producer_epoch, group_id, node_id)
-
-      assert is_integer(response.correlation_id),
-             "correlation_id should be integer"
-
-      end_txn(client, 0, txn_id, producer_id, producer_epoch, false, node_id)
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -535,27 +510,6 @@ defmodule Kayrock.Sanity.TransactionSanityTest do
       end
     end
 
-    @tag api: :end_txn
-    test "EndTxn response has correlation_id", %{kafka: kafka, topic: topic} do
-      {:ok, client} = build_client(kafka)
-      {producer_id, producer_epoch, txn_id, node_id} = init_producer(client, 0, "end-cid")
-
-      {:ok, _} =
-        add_partitions_to_txn(
-          client,
-          0,
-          txn_id,
-          producer_id,
-          producer_epoch,
-          [{topic, [0]}],
-          node_id
-        )
-
-      {:ok, response} = end_txn(client, 0, txn_id, producer_id, producer_epoch, false, node_id)
-
-      assert is_integer(response.correlation_id),
-             "correlation_id should be integer"
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -662,51 +616,6 @@ defmodule Kayrock.Sanity.TransactionSanityTest do
       end
     end
 
-    @tag api: :txn_offset_commit
-    test "V0 response has correlation_id", %{kafka: kafka, topic: topic} do
-      {:ok, client} = build_client(kafka)
-      group_id = "txn-offset-cid-group-#{unique_string()}"
-      {producer_id, producer_epoch, txn_id, node_id} = init_producer(client, 0, "toc-cid")
-
-      {:ok, _} =
-        add_partitions_to_txn(
-          client,
-          0,
-          txn_id,
-          producer_id,
-          producer_epoch,
-          [{topic, [0]}],
-          node_id
-        )
-
-      {:ok, _} =
-        add_offsets_to_txn(client, 0, txn_id, producer_id, producer_epoch, group_id, node_id)
-
-      group_node_id = find_group_coordinator(client, group_id)
-
-      request = %{
-        Kayrock.TxnOffsetCommit.get_request_struct(0)
-        | transactional_id: txn_id,
-          group_id: group_id,
-          producer_id: producer_id,
-          producer_epoch: producer_epoch,
-          topics: [
-            %{
-              name: topic,
-              partitions: [%{partition_index: 0, committed_offset: 0, committed_metadata: ""}]
-            }
-          ]
-      }
-
-      {:ok, response} =
-        with_retry(fn -> Kayrock.client_call(client, request, group_node_id) end,
-          accept_errors: [15, 16]
-        )
-
-      assert is_integer(response.correlation_id), "correlation_id should be integer"
-
-      end_txn(client, 0, txn_id, producer_id, producer_epoch, true, node_id)
-    end
 
     @tag api: :txn_offset_commit
     test "V2 adds committed_leader_epoch in partition entry", %{kafka: kafka, topic: topic} do

--- a/test/sanity/transaction_sanity_test.exs
+++ b/test/sanity/transaction_sanity_test.exs
@@ -1,0 +1,883 @@
+defmodule Kayrock.Sanity.TransactionSanityTest do
+  @moduledoc """
+  Sanity tests for transaction-related APIs.
+
+  Covers:
+  - InitProducerId V0-V2 (API key 22)
+  - AddPartitionsToTxn V0-V1 (API key 24)
+  - AddOffsetsToTxn V0-V1 (API key 25)
+  - EndTxn V0-V1 (API key 26)
+  - TxnOffsetCommit V0-V2 (API key 28)
+
+  Run with:
+      mix test.sanity test/sanity/transaction_sanity_test.exs
+
+  Each API version gets its own transaction (unique transactional_id) to avoid
+  cross-test interference. All requests requiring a coordinator are sent to
+  :random — the Kayrock client will route them correctly.
+  """
+  use Kayrock.SanityCase
+  use ExUnit.Case, async: false
+
+  container(:kafka, KafkaContainer.new(), shared: true)
+
+  # ---------------------------------------------------------------------------
+  # Setup — one shared client + topic per test run
+  # ---------------------------------------------------------------------------
+
+  setup_all %{kafka: kafka} do
+    {:ok, client} = build_client(kafka)
+    topic = create_topic(client, 3)
+    :ok = wait_for_topic(client, topic)
+    %{client: client, topic: topic}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  # Find the transaction coordinator for the given transactional_id.
+  # Returns the node_id to use for all subsequent transaction requests.
+  defp find_txn_coordinator(client, txn_id) do
+    coord_vsn = min(2, Kayrock.FindCoordinator.max_vsn())
+    coord_req = Kayrock.FindCoordinator.get_request_struct(coord_vsn)
+    coord_req = %{coord_req | key: txn_id, key_type: 1}
+
+    {:ok, coord_resp} = with_retry(fn -> Kayrock.client_call(client, coord_req, :random) end)
+
+    assert coord_resp.error_code == 0,
+           "FindCoordinator expected error_code 0, got #{coord_resp.error_code}"
+
+    coord_resp.node_id
+  end
+
+  # Find the group coordinator for the given group_id.
+  # TxnOffsetCommit must be sent to the group coordinator, not the txn coordinator.
+  defp find_group_coordinator(client, group_id) do
+    coord_vsn = min(2, Kayrock.FindCoordinator.max_vsn())
+    coord_req = Kayrock.FindCoordinator.get_request_struct(coord_vsn)
+    coord_req = %{coord_req | key: group_id, key_type: 0}
+
+    {:ok, coord_resp} = with_retry(fn -> Kayrock.client_call(client, coord_req, :random) end)
+
+    assert coord_resp.error_code == 0,
+           "FindCoordinator(group) expected error_code 0, got #{coord_resp.error_code}"
+
+    coord_resp.node_id
+  end
+
+  # Initialize a new producer and return {producer_id, producer_epoch, txn_id, node_id}.
+  # Uses `version` for the InitProducerId request.
+  # Discovers the transaction coordinator first and returns its node_id so all
+  # subsequent transaction requests can be routed to the correct broker.
+  defp init_producer(client, version, prefix) do
+    txn_id = "#{prefix}-#{unique_string()}"
+    node_id = find_txn_coordinator(client, txn_id)
+
+    request = Kayrock.InitProducerId.get_request_struct(version)
+
+    request =
+      if version >= 2 do
+        %{request | transactional_id: txn_id, transaction_timeout_ms: 30_000, tagged_fields: []}
+      else
+        %{request | transactional_id: txn_id, transaction_timeout_ms: 30_000}
+      end
+
+    {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+    assert response.error_code == 0, "InitProducerId V#{version} expected error_code 0"
+    {response.producer_id, response.producer_epoch, txn_id, node_id}
+  end
+
+  # Add a list of topic/partition pairs to the given transaction.
+  defp add_partitions_to_txn(
+         client,
+         version,
+         txn_id,
+         producer_id,
+         producer_epoch,
+         topics_parts,
+         node_id
+       ) do
+    topics =
+      Enum.map(topics_parts, fn {topic, partitions} ->
+        %{topic: topic, partitions: partitions}
+      end)
+
+    request = Kayrock.AddPartitionsToTxn.get_request_struct(version)
+
+    request = %{
+      request
+      | transactional_id: txn_id,
+        producer_id: producer_id,
+        producer_epoch: producer_epoch,
+        topics: topics
+    }
+
+    with_retry(fn -> Kayrock.client_call(client, request, node_id) end,
+      accept_errors: [15, 16]
+    )
+  end
+
+  # Add a consumer group to the given transaction.
+  defp add_offsets_to_txn(
+         client,
+         version,
+         txn_id,
+         producer_id,
+         producer_epoch,
+         group_id,
+         node_id
+       ) do
+    request = Kayrock.AddOffsetsToTxn.get_request_struct(version)
+
+    request = %{
+      request
+      | transactional_id: txn_id,
+        producer_id: producer_id,
+        producer_epoch: producer_epoch,
+        group_id: group_id
+    }
+
+    with_retry(fn -> Kayrock.client_call(client, request, node_id) end,
+      accept_errors: [15, 16]
+    )
+  end
+
+  # Commit or abort a transaction.
+  defp end_txn(client, version, txn_id, producer_id, producer_epoch, commit?, node_id) do
+    request = Kayrock.EndTxn.get_request_struct(version)
+
+    request = %{
+      request
+      | transactional_id: txn_id,
+        producer_id: producer_id,
+        producer_epoch: producer_epoch,
+        transaction_result: commit?
+    }
+
+    with_retry(fn -> Kayrock.client_call(client, request, node_id) end,
+      accept_errors: [15, 16]
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # InitProducerId V0-V2 (API key 22)
+  # ---------------------------------------------------------------------------
+
+  describe "InitProducerId" do
+    for version <- 0..2 do
+      @tag api: :init_producer_id, version: version
+      test "V#{version} returns success with valid producer_id and epoch", %{kafka: kafka} do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+        txn_id = "init-v#{version}-#{unique_string()}"
+        node_id = find_txn_coordinator(client, txn_id)
+
+        request = Kayrock.InitProducerId.get_request_struct(version)
+
+        request =
+          if version >= 2 do
+            %{
+              request
+              | transactional_id: txn_id,
+                transaction_timeout_ms: 30_000,
+                tagged_fields: []
+            }
+          else
+            %{request | transactional_id: txn_id, transaction_timeout_ms: 30_000}
+          end
+
+        {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+
+        assert response.error_code == 0,
+               "V#{version} expected error_code 0, got #{response.error_code}"
+
+        assert is_integer(response.producer_id),
+               "V#{version} producer_id should be integer"
+
+        assert response.producer_id >= 0,
+               "V#{version} producer_id should be non-negative, got #{response.producer_id}"
+
+        assert is_integer(response.producer_epoch),
+               "V#{version} producer_epoch should be integer"
+
+        assert response.producer_epoch >= 0,
+               "V#{version} producer_epoch should be non-negative"
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert response.throttle_time_ms >= 0,
+               "V#{version} throttle_time_ms should be non-negative"
+      end
+    end
+
+    # V0-V1 use nullable_string for transactional_id
+    for version <- 0..1 do
+      @tag api: :init_producer_id, version: version
+      test "V#{version} nil transactional_id (idempotent-only producer) succeeds", %{
+        kafka: kafka
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        request = Kayrock.InitProducerId.get_request_struct(version)
+        request = %{request | transactional_id: nil, transaction_timeout_ms: 30_000}
+
+        {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, :random) end)
+
+        assert response.error_code == 0,
+               "V#{version} nil transactional_id expected error_code 0, got #{response.error_code}"
+
+        assert response.producer_id >= 0
+        assert response.producer_epoch >= 0
+      end
+    end
+
+    # V2 is flexible — response must include tagged_fields
+    @tag api: :init_producer_id, version: 2
+    test "V2 response includes tagged_fields (flexible version)", %{kafka: kafka} do
+      {:ok, client} = build_client(kafka)
+      txn_id = "init-v2-flex-#{unique_string()}"
+      node_id = find_txn_coordinator(client, txn_id)
+
+      request = Kayrock.InitProducerId.get_request_struct(2)
+
+      request = %{
+        request
+        | transactional_id: txn_id,
+          transaction_timeout_ms: 30_000,
+          tagged_fields: []
+      }
+
+      {:ok, response} = with_retry(fn -> Kayrock.client_call(client, request, node_id) end)
+
+      assert response.error_code == 0
+      assert is_list(response.tagged_fields), "V2 response.tagged_fields should be a list"
+    end
+
+    # Repeated calls with same transactional_id must bump epoch
+    @tag api: :init_producer_id
+    test "repeated InitProducerId for same transactional_id bumps producer_epoch", %{
+      kafka: kafka
+    } do
+      {:ok, client} = build_client(kafka)
+      txn_id = "epoch-bump-#{unique_string()}"
+      node_id = find_txn_coordinator(client, txn_id)
+
+      request1 = %{
+        Kayrock.InitProducerId.get_request_struct(0)
+        | transactional_id: txn_id,
+          transaction_timeout_ms: 30_000
+      }
+
+      {:ok, r1} = with_retry(fn -> Kayrock.client_call(client, request1, node_id) end)
+      assert r1.error_code == 0
+
+      request2 = %{
+        Kayrock.InitProducerId.get_request_struct(0)
+        | transactional_id: txn_id,
+          transaction_timeout_ms: 30_000
+      }
+
+      {:ok, r2} = with_retry(fn -> Kayrock.client_call(client, request2, node_id) end)
+      assert r2.error_code == 0
+
+      assert r2.producer_id == r1.producer_id,
+             "Repeated init should return same producer_id"
+
+      assert r2.producer_epoch > r1.producer_epoch,
+             "Repeated init should bump epoch: #{r2.producer_epoch} > #{r1.producer_epoch}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AddPartitionsToTxn V0-V1 (API key 24)
+  # ---------------------------------------------------------------------------
+
+  describe "AddPartitionsToTxn" do
+    for version <- 0..1 do
+      @tag api: :add_partitions_to_txn, version: version
+      test "V#{version} adds topic partition to transaction successfully", %{
+        kafka: kafka,
+        topic: topic
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        {producer_id, producer_epoch, txn_id, node_id} =
+          init_producer(client, 0, "add-parts-v#{version}")
+
+        {:ok, response} =
+          add_partitions_to_txn(
+            client,
+            version,
+            txn_id,
+            producer_id,
+            producer_epoch,
+            [
+              {topic, [0]}
+            ],
+            node_id
+          )
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert response.throttle_time_ms >= 0
+
+        # errors list: each entry has topic + partition_errors
+        assert is_list(response.errors),
+               "V#{version} response.errors should be a list"
+
+        for error_entry <- response.errors do
+          assert is_binary(error_entry.topic), "error_entry.topic should be binary"
+
+          assert is_list(error_entry.partition_errors),
+                 "error_entry.partition_errors should be list"
+
+          for pe <- error_entry.partition_errors do
+            assert is_integer(pe.partition), "partition_error.partition should be integer"
+            assert pe.error_code == 0, "expected error_code 0, got #{pe.error_code}"
+          end
+        end
+
+        # Abort the transaction to avoid dangling state
+        end_txn(client, 0, txn_id, producer_id, producer_epoch, false, node_id)
+      end
+    end
+
+    @tag api: :add_partitions_to_txn
+    test "V0 adds multiple partitions in one call", %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+      {producer_id, producer_epoch, txn_id, node_id} = init_producer(client, 0, "add-multi-parts")
+
+      {:ok, response} =
+        add_partitions_to_txn(
+          client,
+          0,
+          txn_id,
+          producer_id,
+          producer_epoch,
+          [
+            {topic, [0, 1, 2]}
+          ],
+          node_id
+        )
+
+      assert is_list(response.errors)
+
+      # All 3 partitions should succeed (error_code 0)
+      all_partition_errors =
+        response.errors
+        |> Enum.flat_map(& &1.partition_errors)
+
+      for pe <- all_partition_errors do
+        assert pe.error_code == 0,
+               "Expected error_code 0 for partition #{pe.partition}, got #{pe.error_code}"
+      end
+
+      end_txn(client, 0, txn_id, producer_id, producer_epoch, false, node_id)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AddOffsetsToTxn V0-V1 (API key 25)
+  # ---------------------------------------------------------------------------
+
+  describe "AddOffsetsToTxn" do
+    for version <- 0..1 do
+      @tag api: :add_offsets_to_txn, version: version
+      test "V#{version} adds consumer group offsets to transaction", %{
+        kafka: kafka,
+        topic: topic
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+        group_id = "txn-group-v#{version}-#{unique_string()}"
+
+        {producer_id, producer_epoch, txn_id, node_id} =
+          init_producer(client, 0, "add-offs-v#{version}")
+
+        # Must add partitions to transaction first
+        {:ok, _} =
+          add_partitions_to_txn(
+            client,
+            0,
+            txn_id,
+            producer_id,
+            producer_epoch,
+            [{topic, [0]}],
+            node_id
+          )
+
+        {:ok, response} =
+          add_offsets_to_txn(
+            client,
+            version,
+            txn_id,
+            producer_id,
+            producer_epoch,
+            group_id,
+            node_id
+          )
+
+        assert response.error_code == 0,
+               "V#{version} AddOffsetsToTxn expected error_code 0, got #{response.error_code}"
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert response.throttle_time_ms >= 0
+
+        end_txn(client, 0, txn_id, producer_id, producer_epoch, false, node_id)
+      end
+    end
+
+    @tag api: :add_offsets_to_txn
+    test "V0 response has correlation_id", %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+      group_id = "txn-cid-group-#{unique_string()}"
+      {producer_id, producer_epoch, txn_id, node_id} = init_producer(client, 0, "add-offs-cid")
+
+      {:ok, _} =
+        add_partitions_to_txn(
+          client,
+          0,
+          txn_id,
+          producer_id,
+          producer_epoch,
+          [{topic, [0]}],
+          node_id
+        )
+
+      {:ok, response} =
+        add_offsets_to_txn(client, 0, txn_id, producer_id, producer_epoch, group_id, node_id)
+
+      assert is_integer(response.correlation_id),
+             "correlation_id should be integer"
+
+      end_txn(client, 0, txn_id, producer_id, producer_epoch, false, node_id)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # EndTxn V0-V1 (API key 26)
+  # ---------------------------------------------------------------------------
+
+  describe "EndTxn" do
+    for version <- 0..1 do
+      @tag api: :end_txn, version: version
+      test "V#{version} commits transaction successfully (transaction_result: true)", %{
+        kafka: kafka,
+        topic: topic
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        {producer_id, producer_epoch, txn_id, node_id} =
+          init_producer(client, 0, "end-commit-v#{version}")
+
+        # Add a partition first so transaction is active
+        {:ok, _} =
+          add_partitions_to_txn(
+            client,
+            0,
+            txn_id,
+            producer_id,
+            producer_epoch,
+            [{topic, [0]}],
+            node_id
+          )
+
+        {:ok, response} =
+          end_txn(client, version, txn_id, producer_id, producer_epoch, true, node_id)
+
+        assert response.error_code == 0,
+               "V#{version} EndTxn commit expected error_code 0, got #{response.error_code}"
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert response.throttle_time_ms >= 0
+      end
+
+      @tag api: :end_txn, version: version
+      test "V#{version} aborts transaction successfully (transaction_result: false)", %{
+        kafka: kafka,
+        topic: topic
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+
+        {producer_id, producer_epoch, txn_id, node_id} =
+          init_producer(client, 0, "end-abort-v#{version}")
+
+        {:ok, _} =
+          add_partitions_to_txn(
+            client,
+            0,
+            txn_id,
+            producer_id,
+            producer_epoch,
+            [{topic, [0]}],
+            node_id
+          )
+
+        {:ok, response} =
+          end_txn(client, version, txn_id, producer_id, producer_epoch, false, node_id)
+
+        assert response.error_code == 0,
+               "V#{version} EndTxn abort expected error_code 0, got #{response.error_code}"
+
+        assert is_integer(response.throttle_time_ms)
+        assert response.throttle_time_ms >= 0
+      end
+    end
+
+    @tag api: :end_txn
+    test "EndTxn response has correlation_id", %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+      {producer_id, producer_epoch, txn_id, node_id} = init_producer(client, 0, "end-cid")
+
+      {:ok, _} =
+        add_partitions_to_txn(
+          client,
+          0,
+          txn_id,
+          producer_id,
+          producer_epoch,
+          [{topic, [0]}],
+          node_id
+        )
+
+      {:ok, response} = end_txn(client, 0, txn_id, producer_id, producer_epoch, false, node_id)
+
+      assert is_integer(response.correlation_id),
+             "correlation_id should be integer"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # TxnOffsetCommit V0-V2 (API key 28)
+  # ---------------------------------------------------------------------------
+
+  describe "TxnOffsetCommit" do
+    for version <- 0..2 do
+      @tag api: :txn_offset_commit, version: version
+      test "V#{version} commits transactional offset successfully", %{
+        kafka: kafka,
+        topic: topic
+      } do
+        version = unquote(version)
+        {:ok, client} = build_client(kafka)
+        group_id = "txn-offset-group-v#{version}-#{unique_string()}"
+
+        {producer_id, producer_epoch, txn_id, node_id} =
+          init_producer(client, 0, "toc-v#{version}")
+
+        # Must add partitions AND offsets-group to txn before TxnOffsetCommit
+        {:ok, _} =
+          add_partitions_to_txn(
+            client,
+            0,
+            txn_id,
+            producer_id,
+            producer_epoch,
+            [{topic, [0]}],
+            node_id
+          )
+
+        {:ok, _} =
+          add_offsets_to_txn(
+            client,
+            0,
+            txn_id,
+            producer_id,
+            producer_epoch,
+            group_id,
+            node_id
+          )
+
+        # TxnOffsetCommit must go to the GROUP coordinator, not the txn coordinator
+        group_node_id = find_group_coordinator(client, group_id)
+
+        # Build the TxnOffsetCommit request
+        request = Kayrock.TxnOffsetCommit.get_request_struct(version)
+
+        partition_entry =
+          if version >= 2 do
+            %{
+              partition_index: 0,
+              committed_offset: 0,
+              committed_leader_epoch: -1,
+              committed_metadata: ""
+            }
+          else
+            %{partition_index: 0, committed_offset: 0, committed_metadata: ""}
+          end
+
+        request = %{
+          request
+          | transactional_id: txn_id,
+            group_id: group_id,
+            producer_id: producer_id,
+            producer_epoch: producer_epoch,
+            topics: [
+              %{
+                name: topic,
+                partitions: [partition_entry]
+              }
+            ]
+        }
+
+        {:ok, response} =
+          with_retry(fn -> Kayrock.client_call(client, request, group_node_id) end,
+            accept_errors: [15, 16]
+          )
+
+        assert is_integer(response.throttle_time_ms),
+               "V#{version} throttle_time_ms should be integer"
+
+        assert response.throttle_time_ms >= 0
+
+        # response.topics is a list of topic-level results
+        assert is_list(response.topics),
+               "V#{version} response.topics should be a list"
+
+        for topic_entry <- response.topics do
+          assert is_binary(topic_entry.name), "topic_entry.name should be binary"
+          assert is_list(topic_entry.partitions), "topic_entry.partitions should be list"
+
+          for part <- topic_entry.partitions do
+            assert is_integer(part.partition_index), "partition_index should be integer"
+
+            assert part.error_code == 0,
+                   "V#{version} partition #{part.partition_index} expected error_code 0, got #{part.error_code}"
+          end
+        end
+
+        # Commit the transaction
+        end_txn(client, 0, txn_id, producer_id, producer_epoch, true, node_id)
+      end
+    end
+
+    @tag api: :txn_offset_commit
+    test "V0 response has correlation_id", %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+      group_id = "txn-offset-cid-group-#{unique_string()}"
+      {producer_id, producer_epoch, txn_id, node_id} = init_producer(client, 0, "toc-cid")
+
+      {:ok, _} =
+        add_partitions_to_txn(
+          client,
+          0,
+          txn_id,
+          producer_id,
+          producer_epoch,
+          [{topic, [0]}],
+          node_id
+        )
+
+      {:ok, _} =
+        add_offsets_to_txn(client, 0, txn_id, producer_id, producer_epoch, group_id, node_id)
+
+      group_node_id = find_group_coordinator(client, group_id)
+
+      request = %{
+        Kayrock.TxnOffsetCommit.get_request_struct(0)
+        | transactional_id: txn_id,
+          group_id: group_id,
+          producer_id: producer_id,
+          producer_epoch: producer_epoch,
+          topics: [
+            %{
+              name: topic,
+              partitions: [%{partition_index: 0, committed_offset: 0, committed_metadata: ""}]
+            }
+          ]
+      }
+
+      {:ok, response} =
+        with_retry(fn -> Kayrock.client_call(client, request, group_node_id) end,
+          accept_errors: [15, 16]
+        )
+
+      assert is_integer(response.correlation_id), "correlation_id should be integer"
+
+      end_txn(client, 0, txn_id, producer_id, producer_epoch, true, node_id)
+    end
+
+    @tag api: :txn_offset_commit
+    test "V2 adds committed_leader_epoch in partition entry", %{kafka: kafka, topic: topic} do
+      {:ok, client} = build_client(kafka)
+      group_id = "txn-v2-epoch-group-#{unique_string()}"
+      {producer_id, producer_epoch, txn_id, node_id} = init_producer(client, 0, "toc-v2-epoch")
+
+      {:ok, _} =
+        add_partitions_to_txn(
+          client,
+          0,
+          txn_id,
+          producer_id,
+          producer_epoch,
+          [{topic, [0]}],
+          node_id
+        )
+
+      {:ok, _} =
+        add_offsets_to_txn(client, 0, txn_id, producer_id, producer_epoch, group_id, node_id)
+
+      group_node_id = find_group_coordinator(client, group_id)
+
+      request = %{
+        Kayrock.TxnOffsetCommit.get_request_struct(2)
+        | transactional_id: txn_id,
+          group_id: group_id,
+          producer_id: producer_id,
+          producer_epoch: producer_epoch,
+          topics: [
+            %{
+              name: topic,
+              partitions: [
+                %{
+                  partition_index: 0,
+                  committed_offset: 0,
+                  committed_leader_epoch: -1,
+                  committed_metadata: ""
+                }
+              ]
+            }
+          ]
+      }
+
+      {:ok, response} =
+        with_retry(fn -> Kayrock.client_call(client, request, group_node_id) end,
+          accept_errors: [15, 16]
+        )
+
+      assert is_list(response.topics)
+
+      for t <- response.topics, p <- t.partitions do
+        assert p.error_code == 0,
+               "V2 partition #{p.partition_index} expected error_code 0, got #{p.error_code}"
+      end
+
+      end_txn(client, 0, txn_id, producer_id, producer_epoch, true, node_id)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Full transaction lifecycle (cross-API)
+  # ---------------------------------------------------------------------------
+
+  describe "Transaction lifecycle" do
+    @tag api: :transaction_lifecycle
+    test "full lifecycle: InitProducerId -> AddPartitions -> Produce -> EndTxn (commit)", %{
+      kafka: kafka,
+      topic: topic
+    } do
+      {:ok, client} = build_client(kafka)
+
+      {producer_id, producer_epoch, txn_id, node_id} =
+        init_producer(client, 0, "lifecycle-commit")
+
+      # Register partition
+      {:ok, add_resp} =
+        add_partitions_to_txn(
+          client,
+          0,
+          txn_id,
+          producer_id,
+          producer_epoch,
+          [{topic, [0]}],
+          node_id
+        )
+
+      assert is_list(add_resp.errors)
+
+      # Commit
+      {:ok, end_resp} = end_txn(client, 0, txn_id, producer_id, producer_epoch, true, node_id)
+      assert end_resp.error_code == 0
+    end
+
+    @tag api: :transaction_lifecycle
+    test "full lifecycle: InitProducerId -> AddPartitions -> EndTxn (abort)", %{
+      kafka: kafka,
+      topic: topic
+    } do
+      {:ok, client} = build_client(kafka)
+      {producer_id, producer_epoch, txn_id, node_id} = init_producer(client, 0, "lifecycle-abort")
+
+      {:ok, _} =
+        add_partitions_to_txn(
+          client,
+          0,
+          txn_id,
+          producer_id,
+          producer_epoch,
+          [{topic, [0]}],
+          node_id
+        )
+
+      {:ok, end_resp} = end_txn(client, 0, txn_id, producer_id, producer_epoch, false, node_id)
+      assert end_resp.error_code == 0
+    end
+
+    @tag api: :transaction_lifecycle
+    test "full lifecycle with AddOffsetsToTxn and TxnOffsetCommit", %{
+      kafka: kafka,
+      topic: topic
+    } do
+      {:ok, client} = build_client(kafka)
+      group_id = "lifecycle-full-group-#{unique_string()}"
+      {producer_id, producer_epoch, txn_id, node_id} = init_producer(client, 0, "lifecycle-full")
+
+      # Step 1: add partition
+      {:ok, _} =
+        add_partitions_to_txn(
+          client,
+          0,
+          txn_id,
+          producer_id,
+          producer_epoch,
+          [{topic, [0]}],
+          node_id
+        )
+
+      # Step 2: add offsets group
+      {:ok, offs_resp} =
+        add_offsets_to_txn(client, 0, txn_id, producer_id, producer_epoch, group_id, node_id)
+
+      assert offs_resp.error_code == 0
+
+      # Step 3: commit transactional offset (must route to GROUP coordinator)
+      group_node_id = find_group_coordinator(client, group_id)
+
+      request = %{
+        Kayrock.TxnOffsetCommit.get_request_struct(0)
+        | transactional_id: txn_id,
+          group_id: group_id,
+          producer_id: producer_id,
+          producer_epoch: producer_epoch,
+          topics: [
+            %{
+              name: topic,
+              partitions: [%{partition_index: 0, committed_offset: 0, committed_metadata: ""}]
+            }
+          ]
+      }
+
+      {:ok, toc_resp} =
+        with_retry(fn -> Kayrock.client_call(client, request, group_node_id) end,
+          accept_errors: [15, 16]
+        )
+
+      assert is_list(toc_resp.topics)
+
+      # Step 4: end transaction
+      {:ok, end_resp} = end_txn(client, 0, txn_id, producer_id, producer_epoch, true, node_id)
+      assert end_resp.error_code == 0
+    end
+  end
+end

--- a/test/support/factories/alter_partition_reassignments_factory.ex
+++ b/test/support/factories/alter_partition_reassignments_factory.ex
@@ -31,6 +31,7 @@ defmodule Kayrock.Test.Factories.AlterPartitionReassignmentsFactory do
     }
 
     # Captured from actual serialization
+    # Fixed: client_id uses int16-prefixed nullable_string (not compact varint)
     expected_binary = <<
       0,
       45,

--- a/test/support/factories/api_versions_factory.ex
+++ b/test/support/factories/api_versions_factory.ex
@@ -125,12 +125,11 @@ defmodule Kayrock.Test.Factories.ApiVersionsFactory do
       0,
       0,
       3,
-      # client_id length
+      # client_id (int16-prefixed nullable_string, NOT compact)
       0,
       15,
-      # client_id
       "kayrock-capture"::binary,
-      # flexible header marker
+      # flexible header tag_buffer
       0,
       # client_software_name (compact string: length+1)
       8,
@@ -287,8 +286,58 @@ defmodule Kayrock.Test.Factories.ApiVersionsFactory do
   end
 
   def response_data(3) do
-    # V3 response not yet supported by Kafka 7.4.0
-    raise "V3 response format not yet captured from broker - broker returns UNSUPPORTED_VERSION"
+    # ApiVersionsResponse V3 uses response header v0 (KIP-511: no tag_buffer)
+    # but the body uses flexible encoding (compact arrays, tagged fields)
+    binary = <<
+      # correlation_id (response header v0 — no tag_buffer!)
+      0,
+      0,
+      0,
+      3,
+      # error_code
+      0,
+      0,
+      # api_keys compact_array: varint(count+1) = 3 (2 entries)
+      3,
+      # Entry 1: Produce api_key=0, min=0, max=9
+      0,
+      0,
+      0,
+      0,
+      0,
+      9,
+      # entry tagged_fields (empty)
+      0,
+      # Entry 2: Fetch api_key=1, min=0, max=13
+      0,
+      1,
+      0,
+      0,
+      0,
+      13,
+      # entry tagged_fields (empty)
+      0,
+      # throttle_time_ms (0)
+      0,
+      0,
+      0,
+      0,
+      # response body tagged_fields (empty)
+      0
+    >>
+
+    expected_struct = %Kayrock.ApiVersions.V3.Response{
+      correlation_id: 3,
+      error_code: 0,
+      throttle_time_ms: 0,
+      api_keys: [
+        %{api_key: 0, min_version: 0, max_version: 9, tagged_fields: []},
+        %{api_key: 1, min_version: 0, max_version: 13, tagged_fields: []}
+      ],
+      tagged_fields: []
+    }
+
+    {binary, expected_struct}
   end
 
   # ============================================
@@ -523,10 +572,10 @@ defmodule Kayrock.Test.Factories.ApiVersionsFactory do
       0,
       0,
       0,
-      # client_id length (0)
+      # client_id (int16-prefixed nullable_string: length 0 for empty string)
       0,
       0,
-      # flexible header marker
+      # flexible header tag_buffer
       0,
       # empty compact_string (0+1)
       1,

--- a/test/support/factories/create_delegation_token_factory.ex
+++ b/test/support/factories/create_delegation_token_factory.ex
@@ -132,6 +132,7 @@ defmodule Kayrock.Test.Factories.CreateDelegationTokenFactory do
     }
 
     # Captured from actual serialization
+    # Fixed: client_id uses int16-prefixed nullable_string (not compact varint)
     expected_binary = <<
       0,
       38,

--- a/test/support/factories/create_topics_factory.ex
+++ b/test/support/factories/create_topics_factory.ex
@@ -412,12 +412,11 @@ defmodule Kayrock.Test.Factories.CreateTopicsFactory do
       0,
       0,
       5,
-      # client_id length
+      # client_id (int16-prefixed nullable_string)
       0,
       4,
-      # client_id
       "test"::binary,
-      # flexible header marker (tagged fields)
+      # flexible header tag_buffer
       0,
       # topics compact array (length + 1 = 2)
       2,

--- a/test/support/factories/delete_groups_factory.ex
+++ b/test/support/factories/delete_groups_factory.ex
@@ -108,11 +108,11 @@ defmodule Kayrock.Test.Factories.DeleteGroupsFactory do
       0,
       0,
       2,
-      # client_id
+      # client_id (int16-prefixed nullable_string)
       0,
       4,
       "test"::binary,
-      # header tagged_fields (empty)
+      # header tag_buffer
       0,
       # groups_names compact array (length + 1 = 2)
       2,

--- a/test/support/factories/delete_topics_factory.ex
+++ b/test/support/factories/delete_topics_factory.ex
@@ -231,12 +231,11 @@ defmodule Kayrock.Test.Factories.DeleteTopicsFactory do
       0,
       0,
       4,
-      # client_id length
+      # client_id (int16-prefixed nullable_string)
       0,
       4,
-      # client_id
       "test"::binary,
-      # flexible header tagged_fields (0)
+      # flexible header tag_buffer
       0,
       # topic_names compact array (length+1 = 2)
       2,

--- a/test/support/factories/describe_groups_factory.ex
+++ b/test/support/factories/describe_groups_factory.ex
@@ -244,11 +244,11 @@ defmodule Kayrock.Test.Factories.DescribeGroupsFactory do
       0,
       0,
       5,
-      # client_id
+      # client_id (int16-prefixed nullable_string)
       0,
       4,
       "test"::binary,
-      # flexible header tagged_fields
+      # flexible header tag_buffer
       0,
       # groups compact array (length+1 = 2)
       2,

--- a/test/support/factories/elect_leaders_factory.ex
+++ b/test/support/factories/elect_leaders_factory.ex
@@ -146,6 +146,7 @@ defmodule Kayrock.Test.Factories.ElectLeadersFactory do
 
     # V2 uses flexible/compact format
     # Captured from actual serialization
+    # Fixed: client_id uses int16-prefixed nullable_string (not compact varint)
     expected_binary = <<
       0,
       43,

--- a/test/support/factories/heartbeat_factory.ex
+++ b/test/support/factories/heartbeat_factory.ex
@@ -220,7 +220,9 @@ defmodule Kayrock.Test.Factories.HeartbeatFactory do
       tagged_fields: []
     }
 
-    # V4 uses compact format
+    # V4 uses flexible format for body fields, but client_id in the header
+    # ALWAYS uses int16-prefixed nullable_string (RequestHeader.json:
+    # ClientId "flexibleVersions": "none"). Header v2 adds tag_buffer <<0>>.
     expected_binary = <<
       # api_key (12)
       0,
@@ -233,11 +235,11 @@ defmodule Kayrock.Test.Factories.HeartbeatFactory do
       0,
       0,
       4,
-      # client_id
+      # client_id (int16-prefixed nullable_string, NOT compact)
       0,
       4,
       "test"::binary,
-      # flexible header marker (tagged fields)
+      # flexible header tag_buffer
       0,
       # group_id (compact string: length+1 = 6)
       6,

--- a/test/support/factories/incremental_alter_configs_factory.ex
+++ b/test/support/factories/incremental_alter_configs_factory.ex
@@ -98,6 +98,7 @@ defmodule Kayrock.Test.Factories.IncrementalAlterConfigsFactory do
     }
 
     # Captured from actual serialization
+    # Fixed: client_id uses int16-prefixed nullable_string (not compact varint)
     expected_binary = <<
       0,
       44,

--- a/test/support/factories/init_producer_id_factory.ex
+++ b/test/support/factories/init_producer_id_factory.ex
@@ -111,11 +111,11 @@ defmodule Kayrock.Test.Factories.InitProducerIdFactory do
       0,
       0,
       2,
-      # client_id
+      # client_id (int16-prefixed nullable_string)
       0,
       4,
       "test"::binary,
-      # header tagged_fields (empty)
+      # header tag_buffer
       0,
       # transactional_id (compact nullable string, length + 1 = 6)
       6,

--- a/test/support/factories/join_group_factory.ex
+++ b/test/support/factories/join_group_factory.ex
@@ -428,11 +428,11 @@ defmodule Kayrock.Test.Factories.JoinGroupFactory do
       0,
       0,
       6,
-      # client_id
+      # client_id (int16-prefixed nullable_string)
       0,
       4,
       "test"::binary,
-      # flexible header marker (tagged fields)
+      # flexible header tag_buffer
       0,
       # group_id (compact string: length+1 = 6)
       6,

--- a/test/support/factories/leave_group_factory.ex
+++ b/test/support/factories/leave_group_factory.ex
@@ -213,11 +213,11 @@ defmodule Kayrock.Test.Factories.LeaveGroupFactory do
       0,
       0,
       4,
-      # client_id
+      # client_id (int16-prefixed nullable_string)
       0,
       4,
       "test"::binary,
-      # flexible header marker
+      # flexible header tag_buffer
       0,
       # group_id (compact string: length+1)
       6,

--- a/test/support/factories/list_groups_factory.ex
+++ b/test/support/factories/list_groups_factory.ex
@@ -128,12 +128,11 @@ defmodule Kayrock.Test.Factories.ListGroupsFactory do
       0,
       0,
       3,
-      # client_id length
+      # client_id (int16-prefixed nullable_string)
       0,
       4,
-      # client_id
       "test"::binary,
-      # flexible header tagged_fields (0)
+      # flexible header tag_buffer
       0,
       # request tagged_fields
       0

--- a/test/support/factories/list_partition_reassignments_factory.ex
+++ b/test/support/factories/list_partition_reassignments_factory.ex
@@ -29,6 +29,7 @@ defmodule Kayrock.Test.Factories.ListPartitionReassignmentsFactory do
     }
 
     # Captured from actual serialization
+    # Fixed: client_id uses int16-prefixed nullable_string (not compact varint)
     expected_binary = <<
       0,
       46,

--- a/test/support/factories/metadata_factory.ex
+++ b/test/support/factories/metadata_factory.ex
@@ -397,12 +397,11 @@ defmodule Kayrock.Test.Factories.MetadataFactory do
       0,
       0,
       9,
-      # client_id length (7)
+      # client_id (int16-prefixed nullable_string)
       0,
       7,
-      # client_id
       "kayrock"::binary,
-      # flexible version header marker
+      # flexible version header tag_buffer
       0,
       # topics compact_array (empty = 0+1)
       1,

--- a/test/support/factories/offset_commit_factory.ex
+++ b/test/support/factories/offset_commit_factory.ex
@@ -512,11 +512,11 @@ defmodule Kayrock.Test.Factories.OffsetCommitFactory do
       0,
       0,
       8,
-      # client_id
+      # client_id (int16-prefixed nullable_string)
       0,
       4,
       "test"::binary,
-      # flexible header marker (tagged fields)
+      # flexible header tag_buffer
       0,
       # group_id (compact string: length+1 = 6)
       6,

--- a/test/support/factories/offset_fetch_factory.ex
+++ b/test/support/factories/offset_fetch_factory.ex
@@ -387,11 +387,11 @@ defmodule Kayrock.Test.Factories.OffsetFetchFactory do
       0,
       0,
       6,
-      # client_id
+      # client_id (int16-prefixed nullable_string)
       0,
       4,
       "test"::binary,
-      # flexible header marker (tagged fields)
+      # flexible header tag_buffer
       0,
       # group_id (compact string: length+1 = 6)
       6,

--- a/test/support/factories/sync_group_factory.ex
+++ b/test/support/factories/sync_group_factory.ex
@@ -258,11 +258,11 @@ defmodule Kayrock.Test.Factories.SyncGroupFactory do
       0,
       0,
       4,
-      # client_id
+      # client_id (int16-prefixed nullable_string)
       0,
       4,
       "test"::binary,
-      # flexible header marker (tagged fields)
+      # flexible header tag_buffer
       0,
       # group_id (compact string: length+1 = 6)
       6,

--- a/test/support/integration_helpers.ex
+++ b/test/support/integration_helpers.ex
@@ -30,8 +30,15 @@ defmodule Kayrock.IntegrationHelpers do
   - `wait_for_topic/3` - Wait for topic to be ready (future enhancement)
   """
 
-  import Kayrock.TestSupport, only: [unique_string: 0]
-  import Kayrock.RequestFactory, only: [create_topic_request: 2]
+  import Kayrock.TestSupport, only: [unique_string: 0, with_retry: 1, with_retry: 2]
+
+  import Kayrock.RequestFactory,
+    only: [
+      create_topic_request: 2,
+      find_coordinator_request: 2,
+      join_group_request: 2,
+      sync_group_request: 4
+    ]
 
   alias Testcontainers.Container
 
@@ -190,5 +197,91 @@ defmodule Kayrock.IntegrationHelpers do
         Process.sleep(100)
         wait_for_topic(client_pid, topic_name, retries - 1)
     end
+  end
+
+  @doc """
+  Joins and syncs a consumer group, returning the coordinator info needed for
+  subsequent API calls (heartbeat, offset commit, etc.).
+
+  Handles the full lifecycle: FindCoordinator -> JoinGroup -> SyncGroup.
+  For JoinGroup V4+ (KIP-394), automatically handles the two-step join protocol
+  where the broker returns MEMBER_ID_REQUIRED (error 79) on the first attempt.
+
+  ## Parameters
+
+    - `client_pid` - The Kayrock client process ID
+    - `group_id` - Consumer group ID
+    - `topic_name` - Topic name for the group subscription
+    - `opts` - Optional keyword list:
+      - `:api_version` - Version to use for all APIs (default: 2). Each API is
+        capped to its own max_vsn automatically.
+      - `:partitions` - Partition list for assignment (default: [0, 1, 2])
+
+  ## Returns
+
+    `{node_id, generation_id, member_id}`
+
+  ## Example
+
+      {node_id, generation_id, member_id} =
+        join_and_sync_group(client_pid, "my-group", topic_name)
+  """
+  def join_and_sync_group(client_pid, group_id, topic_name, opts \\ []) do
+    api_version = Keyword.get(opts, :api_version, 2)
+    partitions = Keyword.get(opts, :partitions, [0, 1, 2])
+
+    # Find coordinator
+    coordinator_request = find_coordinator_request(group_id, min(api_version, 2))
+
+    {:ok, coordinator_response} =
+      with_retry(fn ->
+        Kayrock.client_call(client_pid, coordinator_request, 1)
+      end)
+
+    node_id = coordinator_response.node_id
+
+    # Join group
+    join_version = min(api_version, 5)
+    join_request = join_group_request(%{group_id: group_id, topics: [topic_name]}, join_version)
+
+    {:ok, join_response} =
+      with_retry(
+        fn -> Kayrock.client_call(client_pid, join_request, node_id) end,
+        accept_errors: [79]
+      )
+
+    # Handle MEMBER_ID_REQUIRED (KIP-394) for JoinGroup V4+
+    join_response =
+      if join_response.error_code == 79 do
+        retry_request =
+          join_group_request(
+            %{group_id: group_id, topics: [topic_name], member_id: join_response.member_id},
+            join_version
+          )
+
+        {:ok, resp} =
+          with_retry(fn ->
+            Kayrock.client_call(client_pid, retry_request, node_id)
+          end)
+
+        resp
+      else
+        join_response
+      end
+
+    generation_id = join_response.generation_id
+    member_id = join_response.member_id
+
+    # Sync group
+    assignments = [
+      %{member_id: member_id, topic: topic_name, partitions: partitions}
+    ]
+
+    sync_request =
+      sync_group_request(group_id, member_id, assignments, min(api_version, 3))
+
+    {:ok, _sync_response} = Kayrock.client_call(client_pid, sync_request, node_id)
+
+    {node_id, generation_id, member_id}
   end
 end

--- a/test/support/sanity_case.ex
+++ b/test/support/sanity_case.ex
@@ -1,0 +1,21 @@
+defmodule Kayrock.SanityCase do
+  @moduledoc """
+  ExUnit case template for sanity integration tests.
+
+  Tags tests with :sanity (excluded by default).
+  Imports IntegrationHelpers and TestSupport.
+  """
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      @moduletag :sanity
+      import Testcontainers.ExUnit
+      import Kayrock.IntegrationHelpers
+      import Kayrock.TestSupport
+
+      alias Testcontainers.Container
+      alias Testcontainers.KafkaContainer
+    end
+  end
+end

--- a/test/support/test_support.ex
+++ b/test/support/test_support.ex
@@ -166,6 +166,8 @@ defmodule Kayrock.TestSupport do
 
   # Transient errors that indicate "try again later"
   @transient_errors [
+    # COORDINATOR_LOAD_IN_PROGRESS
+    14,
     # COORDINATOR_NOT_AVAILABLE
     15,
     # NOT_COORDINATOR
@@ -173,9 +175,7 @@ defmodule Kayrock.TestSupport do
     # UNKNOWN_MEMBER_ID (often transient during rebalance)
     25,
     # REBALANCE_IN_PROGRESS
-    27,
-    # COORDINATOR_LOAD_IN_PROGRESS
-    79
+    27
   ]
 
   defp do_with_retry(0, _fun, result, _delay_ms, _accept_errors), do: result

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,21 +1,22 @@
-# Configure ExUnit to exclude integration/chaos by default
-ExUnit.configure(exclude: [:integration, :chaos])
+# Configure ExUnit to exclude integration/chaos/sanity by default
+ExUnit.configure(exclude: [:integration, :chaos, :sanity])
 ExUnit.start()
 
-# Check if we need Testcontainers (integration or chaos tests requested)
-# Detects --only integration, --only chaos, --include integration, --include chaos
+# Check if we need Testcontainers (integration, chaos, or sanity tests requested)
+# Detects --only integration, --only chaos, --only sanity, --include integration, etc.
 needs_testcontainers? =
   System.get_env("ENABLE_TESTCONTAINERS") == "true" or
     Enum.any?(System.argv(), fn arg ->
       arg in ["--only", "--include"] or
         String.contains?(arg, "integration") or
-        String.contains?(arg, "chaos")
+        String.contains?(arg, "chaos") or
+        String.contains?(arg, "sanity")
     end) or
     System.argv()
     |> Enum.chunk_every(2, 1, :discard)
     |> Enum.any?(fn
-      ["--only", tag] -> tag in ["integration", "chaos"]
-      ["--include", tag] -> tag in ["integration", "chaos"]
+      ["--only", tag] -> tag in ["integration", "chaos", "sanity"]
+      ["--include", tag] -> tag in ["integration", "chaos", "sanity"]
       _ -> false
     end)
 


### PR DESCRIPTION
Protocol fixes:
- Handle nil client_id in both flexible (header v2) and non-flexible (header v1) request headers. byte_size(nil) crashed with ArgumentError; now serializes as <<-1::16-signed>> per Kafka nullable_string encoding.
- Fix ApiVersions V3 response deserialization (KIP-511): ApiVersionsResponse always uses response header v0 (no tag_buffer), even for flexible versions. The deserializer was incorrectly consuming a header tag_buffer byte.
- Add nil guards for compact_string/compact_bytes serialization.
- Preserve struct handling for metadata/assignment in flexible versions.
- Handle connection drops gracefully instead of crashing the client.

Test infrastructure:
- Add sanity test suite against real Kafka via testcontainers (mix test.sanity) covering admin, consumer group, stateless, topic, and transaction APIs.
- Add flexible header integration tests (ApiVersions V3, Metadata V9, Heartbeat V4, FindCoordinator V3).
- Add comprehensive unit tests for request header wire format covering all 20 APIs with flexible versions.
- Add GitHub Actions workflow for sanity tests with retry logic.